### PR TITLE
Add vault protection

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:slim
+FROM ubuntu:24.04
 
 # Install required packages
 RUN apt-get update && apt-get install -y \
@@ -8,15 +8,16 @@ RUN apt-get update && apt-get install -y \
     build-essential \
     vim \
     bash \
+    wget \
     && rm -rf /var/lib/apt/lists/*
 
 # Create non-root user
 RUN useradd -m -s /bin/bash vscode && \
     chown -R vscode:vscode /home/vscode
 
-# Update npm and install corepack as root
-RUN npm install -g npm corepack && \
-    chown -R vscode:vscode /usr/local/lib/node_modules
+# # Update npm and install corepack as root
+# RUN npm install -g npm corepack && \
+#     chown -R vscode:vscode /usr/local/lib/node_modules
 
 # Switch to non-root user
 USER vscode

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -23,6 +23,8 @@ jobs:
         run: |
           asdf install starknet-foundry 0.54.0
           asdf set -u starknet-foundry 0.54.0 
+          sed -i 's/^starknet-foundry .*/starknet-foundry 0.54.0/' .tool-versions
+          cat .tool-versions
     
       - name: Install Voyager Verifier
         run: |

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -21,7 +21,8 @@ jobs:
 
       - name: install foundry
         run: |
-          asdf install starknet-foundry 0.53.0-rc.0  
+          asdf install starknet-foundry 0.54.0
+          asdf set -u starknet-foundry 0.54.0 
     
       - name: Install Voyager Verifier
         run: |

--- a/.github/workflows/deploy_testnet.yaml
+++ b/.github/workflows/deploy_testnet.yaml
@@ -18,6 +18,9 @@ jobs:
       - name: install foundry
         run: |
           asdf install starknet-foundry 0.54.0
+          asdf set -u starknet-foundry 0.54.0 
+          sed -i 's/^starknet-foundry .*/starknet-foundry 0.54.0/' .tool-versions
+          cat .tool-versions
           
       - name: Retrieve account info
         run: |

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 scarb 2.12.2
-starknet-foundry 0.54.0
+starknet-foundry 0.49.0

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -20,7 +20,7 @@ unstable-add-statements-functions-debug-info = true
 inlining-strategy = "avoid"
 
 [profile.release.cairo]
-inlining-strategy = "avoid"
+inlining-strategy = 100
 
 [workspace.tool.scarb]
 allow-prebuilt-plugins = ["snforge_std"]

--- a/workspace/apps/perpetuals/contracts/src/core/components/deleverage/deleverage_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/deleverage/deleverage_manager.cairo
@@ -53,10 +53,11 @@ pub(crate) mod DeleverageManager {
     };
     use crate::core::components::external_components::interface::EXTERNAL_COMPONENT_DELEVERAGES;
     use crate::core::components::external_components::named_component::ITypedComponent;
+    use crate::core::components::vaults::vaults::Vaults::InternalTrait as VaultsInternal;
+    use crate::core::components::vaults::vaults::{Vaults as VaultsComponent};
     use crate::core::types::position::{Position, PositionDiff};
     use crate::core::value_risk_calculator::deleveraged_position_validations;
     use super::{AssetId, Deleverage, IDeleverageManager};
-
 
     #[event]
     #[derive(Drop, starknet::Event)]
@@ -82,6 +83,8 @@ pub(crate) mod DeleverageManager {
         AccessControlEvent: AccessControlComponent::Event,
         #[flat]
         RolesEvent: RolesComponent::Event,
+        #[flat]
+        VaultsEvent: VaultsComponent::Event,
     }
 
     #[storage]
@@ -105,6 +108,8 @@ pub(crate) mod DeleverageManager {
         src5: SRC5Component::Storage,
         #[substorage(v0)]
         pub request_approvals: RequestApprovalsComponent::Storage,
+        #[substorage(v0)]
+        pub vaults: VaultsComponent::Storage,
     }
 
     component!(path: FulfillmentComponent, storage: fulfillment_tracking, event: FulfillmentEvent);
@@ -118,6 +123,8 @@ pub(crate) mod DeleverageManager {
     component!(
         path: RequestApprovalsComponent, storage: request_approvals, event: RequestApprovalsEvent,
     );
+    component!(path: VaultsComponent, storage: vaults, event: VaultsEvent);
+
 
     #[abi(embed_v0)]
     impl TypedComponent of ITypedComponent<ContractState> {
@@ -203,6 +210,9 @@ pub(crate) mod DeleverageManager {
                     position: deleverager_position,
                     position_diff: deleverager_position_diff,
                     tvtr_before: Default::default(),
+                    vault_protection_config: self
+                        .vaults
+                        .get_vault_protection_config(deleverager_position_id),
                 );
 
             // Apply diffs

--- a/workspace/apps/perpetuals/contracts/src/core/components/liquidation/liquidation_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/liquidation/liquidation_manager.cairo
@@ -76,6 +76,9 @@ pub(crate) mod LiquidationManager {
     use crate::core::utils::{validate_signature, validate_trade};
     use crate::core::value_risk_calculator::liquidated_position_validations;
     use super::{ILiquidationManager, Liquidate, Order};
+    use crate::core::components::vaults::vaults::Vaults::InternalTrait as VaultsInternal;
+    use crate::core::components::vaults::vaults::{Vaults as VaultsComponent};
+
 
 
     #[event]
@@ -100,6 +103,8 @@ pub(crate) mod LiquidationManager {
         AccessControlEvent: AccessControlComponent::Event,
         #[flat]
         RolesEvent: RolesComponent::Event,
+        #[flat]
+        VaultsEvent: VaultsComponent::Event,        
     }
 
     #[storage]
@@ -123,6 +128,8 @@ pub(crate) mod LiquidationManager {
         src5: SRC5Component::Storage,
         #[substorage(v0)]
         pub request_approvals: RequestApprovalsComponent::Storage,
+        #[substorage(v0)]
+        pub vaults: VaultsComponent::Storage,        
     }
 
     component!(path: FulfillmentComponent, storage: fulfillment_tracking, event: FulfillmentEvent);
@@ -136,6 +143,7 @@ pub(crate) mod LiquidationManager {
     component!(
         path: RequestApprovalsComponent, storage: request_approvals, event: RequestApprovalsEvent,
     );
+    component!(path: VaultsComponent, storage: vaults, event: VaultsEvent);
 
 
     #[abi(embed_v0)]
@@ -277,6 +285,7 @@ pub(crate) mod LiquidationManager {
                     position: liquidator_position,
                     position_diff: liquidator_position_diff,
                     tvtr_before: Default::default(),
+                    vault_protection_config: self.vaults.get_vault_protection_config(liquidator_position_id)
                 );
 
             // Apply Diffs.

--- a/workspace/apps/perpetuals/contracts/src/core/components/positions/positions.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/positions/positions.cairo
@@ -3,6 +3,7 @@ pub mod Positions {
     use core::nullable::{FromNullableResult, match_nullable};
     use core::num::traits::Zero;
     use core::panic_with_felt252;
+    use core::panics::panic_with_byte_array;
     use openzeppelin::access::accesscontrol::AccessControlComponent;
     use openzeppelin::introspection::src5::SRC5Component;
     use perpetuals::core::components::assets::AssetsComponent;
@@ -50,6 +51,7 @@ pub mod Positions {
     use starkware_utils::storage::utils::AddToStorage;
     use starkware_utils::time::time::{Timestamp, validate_expiration};
     use crate::core::components::snip::SNIP12MetadataImpl;
+    use crate::core::components::vaults::types::VaultProtectionParams;
     use crate::core::errors::{
         INVALID_AMOUNT_SIGN, INVALID_BASE_CHANGE, INVALID_SAME_POSITIONS, INVALID_ZERO_AMOUNT,
     };
@@ -616,6 +618,7 @@ pub mod Positions {
             position: StoragePath<Position>,
             position_diff: PositionDiff,
             tvtr_before: Nullable<PositionTVTR>,
+            vault_protection_config: Option<VaultProtectionParams>,
         ) -> PositionTVTR {
             let asset_enriched_position_diff = self.enrich_asset(:position, :position_diff);
             let tvtr_before = match match_nullable(tvtr_before) {
@@ -637,6 +640,27 @@ pub mod Positions {
                 :tvtr_before, synthetic_enriched_position_diff: asset_enriched_position_diff,
             );
             assert_healthy_or_healthier(:position_id, :tvtr);
+            if let Option::Some(config) = vault_protection_config {
+                {
+                    let tv_after = tvtr.after.total_value;
+                    let tv_at_last_check = config.tv_at_check;
+                    let max_tvtr_loss = config.max_tv_loss;
+                    let delta = tv_after - tv_at_last_check;
+                    if (delta < 0_i64.into()) {
+                        let tv_loss = delta.abs();
+                        if (tv_loss >= max_tvtr_loss) {
+                            panic_with_byte_array(
+                                err: @format!(
+                                    "Vault Protection Limit Exceeded, tv_at_last_check: {}, tv_after_operation: {}, max_allowed_loss : {}",
+                                    tv_at_last_check,
+                                    tv_after,
+                                    max_tvtr_loss,
+                                ),
+                            );
+                        }
+                    }
+                }
+            }
             tvtr.after
         }
 

--- a/workspace/apps/perpetuals/contracts/src/core/components/transfer/transfer_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/transfer/transfer_manager.cairo
@@ -298,8 +298,7 @@ pub(crate) mod TransferManager {
             collateral_id: AssetId,
             amount: u64,
         ) {
-            // Parameters
-
+            assert!(!self.vaults.is_vault_position(position_id), "VAULT_CANNOT_TRANSFER");
             let (position_diff_sender, position_diff_recipient) = if (collateral_id == self
                 .assets
                 .get_collateral_id()) {
@@ -333,6 +332,7 @@ pub(crate) mod TransferManager {
                     position: sender_position,
                     position_diff: position_diff_sender,
                     tvtr_before: Default::default(),
+                    vault_protection_config: Option::None,
                 );
 
             // Execute transfer

--- a/workspace/apps/perpetuals/contracts/src/core/components/vaults/events.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/vaults/events.cairo
@@ -69,3 +69,11 @@ pub struct VaultProtectionReset {
     pub new_tv_at_check: i128,
     pub new_max_tv_loss: u128,
 }
+
+#[derive(Debug, Drop, PartialEq, starknet::Event)]
+pub struct PerVaultProtectionLimitUpdated {
+    #[key]
+    pub vault_position_id: PositionId,
+    pub old_limit: u32,
+    pub new_limit: u32,
+}

--- a/workspace/apps/perpetuals/contracts/src/core/components/vaults/events.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/vaults/events.cairo
@@ -58,3 +58,14 @@ pub struct RedeemVaultShares {
     pub collateral_received: u64,
     pub collateral_requested: u64,
 }
+
+
+#[derive(Debug, Drop, PartialEq, starknet::Event)]
+pub struct VaultProtectionReset {
+    #[key]
+    pub vault_position_id: PositionId,
+    pub old_tv_at_check: i128,
+    pub old_max_tv_loss: u128,
+    pub new_tv_at_check: i128,
+    pub new_max_tv_loss: u128,
+}

--- a/workspace/apps/perpetuals/contracts/src/core/components/vaults/events.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/vaults/events.cairo
@@ -27,3 +27,34 @@ pub struct InvestInVault {
     pub user_investment: u64,
     pub correlation_id: felt252,
 }
+
+
+#[derive(Debug, Drop, PartialEq, starknet::Event)]
+pub struct LiquidateVaultShares {
+    #[key]
+    pub vault_position_id: PositionId,
+    #[key]
+    pub liquidated_position_id: PositionId,
+    #[key]
+    pub vault_asset_id: AssetId,
+    #[key]
+    pub shares_liquidated: u64,
+    pub collateral_received: u64,
+}
+
+#[derive(Debug, Drop, PartialEq, starknet::Event)]
+pub struct RedeemVaultShares {
+    #[key]
+    pub vault_position_id: PositionId,
+    #[key]
+    pub redeeming_position_id: PositionId,
+    #[key]
+    pub receiving_position_id: PositionId,
+    #[key]
+    pub vault_asset_id: AssetId,
+    #[key]
+    pub invested_asset_id: AssetId,
+    pub shares_redeemed: u64,
+    pub collateral_received: u64,
+    pub collateral_requested: u64,
+}

--- a/workspace/apps/perpetuals/contracts/src/core/components/vaults/types.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/vaults/types.cairo
@@ -1,8 +1,18 @@
 use perpetuals::core::types::asset::AssetId;
+use starkware_utils::time::time::Seconds;
 
 #[derive(Copy, Debug, Default, Drop, Hash, PartialEq, Serde, starknet::Store)]
 pub struct VaultConfig {
     pub version: u8,
     pub asset_id: AssetId,
     pub position_id: u32,
+    pub last_tv_check: Seconds,
+    pub tv_at_check: i128,
+    pub max_tv_loss: u128,
+}
+
+#[derive(Copy, Debug, Default, Drop, Hash, PartialEq, Serde)]
+pub struct VaultProtectionParams {
+    pub tv_at_check: i128,
+    pub max_tv_loss: u128,
 }

--- a/workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults.cairo
@@ -14,7 +14,8 @@ pub trait IVaults<TContractState> {
 
 #[starknet::component]
 pub mod Vaults {
-    use core::num::traits::{WideMul, Zero};
+    use RolesComponent::InternalTrait as RolesInternalTrait;
+    use core::num::traits::Zero;
     use core::panic_with_felt252;
     use openzeppelin::access::accesscontrol::AccessControlComponent;
     use openzeppelin::interfaces::erc4626::{IERC4626Dispatcher, IERC4626DispatcherTrait};
@@ -39,6 +40,7 @@ pub mod Vaults {
     use starkware_utils::components::request_approvals::RequestApprovalsComponent;
     use starkware_utils::components::roles::RolesComponent;
     use starkware_utils::math::abs::Abs;
+    use starkware_utils::math::utils::mul_wide_and_floor_div;
     use starkware_utils::signature::stark::Signature;
     use starkware_utils::storage::iterable_map::{
         IterableMapIntoIterImpl, IterableMapReadAccessImpl, IterableMapWriteAccessImpl,
@@ -51,13 +53,13 @@ pub mod Vaults {
     use crate::core::types::vault::ConvertPositionToVault;
     use crate::core::utils::validate_signature;
     use super::{CHECK_FREQUENCY, IVaults, STORAGE_VERSION, VaultProtectionParams};
-    
 
 
     #[event]
     #[derive(Drop, PartialEq, starknet::Event)]
     pub enum Event {
         VaultOpened: events::VaultOpened,
+        VaultProtectionReset: events::VaultProtectionReset,
     }
 
 
@@ -128,13 +130,12 @@ pub mod Vaults {
 
             let current_config = self.registered_vaults_by_position.read(vault_position);
             let current_time = starknet::get_block_timestamp();
-            let last_check = current_config.last_tv_check;
-            if (current_time - last_check >= CHECK_FREQUENCY) {
+            let last_check_time = current_config.last_tv_check;
+            if (current_time - last_check_time >= CHECK_FREQUENCY) {
                 let positions = get_dep_component!(@self, Positions);
                 let position_tv_tr = positions.get_position_tv_tr(vault_position);
                 let tv_at_check = position_tv_tr.total_value;
-                let scaled_tv: u256 = tv_at_check.abs().wide_mul(50);
-                let max_tv_loss: u128 = (scaled_tv / 1000).try_into().unwrap();
+                let max_tv_loss = mul_wide_and_floor_div(tv_at_check.abs(), 50, 1000).unwrap();
                 let updated_config = VaultConfig {
                     version: current_config.version,
                     asset_id: current_config.asset_id,
@@ -266,6 +267,46 @@ pub mod Vaults {
                         },
                     ),
                 )
+        }
+
+        fn force_reset_protection_limit(
+            ref self: ComponentState<TContractState>,
+            vault_position: PositionId,
+            percentage_basis_points: u32,
+        ) {
+            get_dep_component!(@self, Roles).only_app_governor();
+
+            let current_config = self.get_vault_config_for_position(:vault_position);
+            let positions = get_dep_component!(@self, Positions);
+            let position_tv_tr = positions.get_position_tv_tr(vault_position);
+            let tv_at_check = position_tv_tr.total_value;
+            let max_tv_loss = mul_wide_and_floor_div(
+                tv_at_check.abs(), percentage_basis_points.into() * 10, 1000,
+            )
+                .unwrap();
+
+            let updated_config = VaultConfig {
+                version: current_config.version,
+                asset_id: current_config.asset_id,
+                position_id: current_config.position_id,
+                last_tv_check: starknet::get_block_timestamp(),
+                tv_at_check: tv_at_check,
+                max_tv_loss: max_tv_loss,
+            };
+
+            self.registered_vaults_by_position.write(vault_position, updated_config);
+            self.registered_vaults_by_asset.write(current_config.asset_id, updated_config);
+
+            self
+                .emit(
+                    events::VaultProtectionReset {
+                        vault_position_id: vault_position,
+                        old_tv_at_check: current_config.tv_at_check,
+                        old_max_tv_loss: current_config.max_tv_loss,
+                        new_tv_at_check: updated_config.tv_at_check,
+                        new_max_tv_loss: updated_config.max_tv_loss,
+                    },
+                );
         }
     }
 }

--- a/workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults_contract.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults_contract.cairo
@@ -95,6 +95,8 @@ pub(crate) mod VaultsManager {
     #[derive(Drop, starknet::Event)]
     pub enum Event {
         InvestInVault: events::InvestInVault,
+        LiquidateVaultShares: events::LiquidateVaultShares,
+        RedeemVaultShares: events::RedeemVaultShares,
         #[flat]
         FulfillmentEvent: FulfillmentComponent::Event,
         #[flat]
@@ -241,6 +243,10 @@ pub(crate) mod VaultsManager {
                 !self.vaults.is_vault_position(receiving_position_id),
                 'RECEIVING_POSITION_IS_VAULT',
             );
+            assert(
+                self.vaults.is_vault_position(vault_config.position_id.into()),
+                'TARGET_POSITION_NOT_VAULT',
+            );
             let vault_share_config = self.assets.get_asset_config(vault_config.asset_id);
 
             let vault_dispatcher = IERC4626Dispatcher {
@@ -287,6 +293,7 @@ pub(crate) mod VaultsManager {
                     position: sending_position_snapshot,
                     position_diff: sending_position_diff,
                     tvtr_before: Default::default(),
+                    vault_protection_config: Option::None,
                 );
 
             self
@@ -402,6 +409,21 @@ pub(crate) mod VaultsManager {
                     :actual_collateral_user,
                     validate_user_order: false,
                     user_signature: array![0, 0].span(),
+                );
+
+            self
+                .emit(
+                    events::LiquidateVaultShares {
+                        vault_position_id: self
+                            .vaults
+                            .get_vault_config_for_asset(liquidated_asset_id)
+                            .position_id
+                            .into(),
+                        liquidated_position_id: liquidated_position_id,
+                        vault_asset_id: liquidated_asset_id,
+                        shares_liquidated: actual_shares_user.abs().try_into().unwrap(),
+                        collateral_received: actual_collateral_user.abs().try_into().unwrap(),
+                    },
                 );
         }
     }
@@ -576,6 +598,9 @@ pub(crate) mod VaultsManager {
                     position: vault_position,
                     position_diff: vault_position_diff,
                     tvtr_before: Default::default(),
+                    vault_protection_config: self
+                        .vaults
+                        .get_vault_protection_config(vault_position_id),
                 );
 
             self
@@ -632,6 +657,7 @@ pub(crate) mod VaultsManager {
                         position: redeeming_position,
                         position_diff: redeeming_position_diff,
                         tvtr_before: Default::default(),
+                        vault_protection_config: Option::None,
                     );
             }
 
@@ -654,6 +680,20 @@ pub(crate) mod VaultsManager {
                 new_perps_contract_balance == perps_contract_balance_before,
                 'COLLATERAL_NOT_RETURNED',
             );
+
+            self
+                .emit(
+                    events::RedeemVaultShares {
+                        vault_position_id: vault_position_id,
+                        redeeming_position_id: redeeming_position_id,
+                        receiving_position_id: receiving_position_id,
+                        shares_redeemed: amount_to_burn.abs().try_into().unwrap(),
+                        collateral_received: value_to_receive.abs().try_into().unwrap(),
+                        collateral_requested: order.quote_amount.abs(),
+                        vault_asset_id: vault_config.asset_id,
+                        invested_asset_id: self.assets.get_collateral_id(),
+                    },
+                );
         }
     }
 }

--- a/workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults_contract.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults_contract.cairo
@@ -615,12 +615,6 @@ pub(crate) mod VaultsManager {
                     position: vault_position, asset_id: self.assets.get_collateral_id(),
                 );
 
-            self
-                .positions
-                .validate_asset_balance_is_not_negative(
-                    position: redeeming_position, asset_id: order.base_asset_id,
-                );
-
             // user health checks
             if (self.positions.is_liquidatable(redeeming_position_id)) {
                 let (asset_id, qty) = redeeming_position_diff.asset_diff.unwrap();
@@ -665,6 +659,11 @@ pub(crate) mod VaultsManager {
                 .positions
                 .apply_diff(
                     position_id: redeeming_position_id, position_diff: redeeming_position_diff,
+                );
+            self
+                .positions
+                .validate_asset_balance_is_not_negative(
+                    position: redeeming_position, asset_id: order.base_asset_id,
                 );
 
             // no need to validate health as can only receive collateral

--- a/workspace/apps/perpetuals/contracts/src/core/core.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/core.cairo
@@ -682,6 +682,12 @@ pub mod Core {
         ) {
             self.vaults.force_reset_protection_limit(:vault_position, :percentage_basis_points);
         }
+
+        fn update_vault_protection_limit(
+            ref self: ContractState, vault_position: PositionId, limit: u32,
+        ) {
+            self.vaults.update_vault_protection_limit(:vault_position, :limit);
+        }
     }
 
     #[generate_trait]

--- a/workspace/apps/perpetuals/contracts/src/core/core.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/core.cairo
@@ -676,6 +676,12 @@ pub mod Core {
                     operator_nonce: operator_nonce, :signature, :order, :correlation_id,
                 )
         }
+
+        fn force_reset_protection_limit(
+            ref self: ContractState, vault_position: PositionId, percentage_basis_points: u32,
+        ) {
+            self.vaults.force_reset_protection_limit(:vault_position, :percentage_basis_points);
+        }
     }
 
     #[generate_trait]

--- a/workspace/apps/perpetuals/contracts/src/core/core.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/core.cairo
@@ -50,6 +50,7 @@ pub mod Core {
     use crate::core::components::snip::SNIP12MetadataImpl;
     use crate::core::components::transfer::transfer_manager::ITransferManagerDispatcherTrait;
     use crate::core::components::vaults::events as vault_events;
+    use crate::core::components::vaults::vaults::Vaults::InternalTrait as VaultsInternal;
     use crate::core::components::vaults::vaults::{IVaults, Vaults as VaultsComponent};
     use crate::core::components::vaults::vaults_contract::IVaultExternalDispatcherTrait;
     use crate::core::components::withdrawal::withdrawal_manager::IWithdrawalManagerDispatcherTrait;
@@ -767,6 +768,9 @@ pub mod Core {
                     position: position_a,
                     position_diff: position_diff_a,
                     tvtr_before: tvtr_a_before,
+                    vault_protection_config: self
+                        .vaults
+                        .get_vault_protection_config(order_a.position_id),
                 );
             let tvtr_b_after = self
                 .positions
@@ -775,6 +779,9 @@ pub mod Core {
                     position: position_b,
                     position_diff: position_diff_b,
                     tvtr_before: tvtr_b_before,
+                    vault_protection_config: self
+                        .vaults
+                        .get_vault_protection_config(order_b.position_id),
                 );
 
             // Apply Diffs.

--- a/workspace/apps/perpetuals/contracts/src/core/interface.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/interface.cairo
@@ -134,4 +134,8 @@ pub trait ICore<TContractState> {
         actual_shares_user: i64,
         actual_collateral_user: i64,
     );
+
+    fn force_reset_protection_limit(
+        ref self: TContractState, vault_position: PositionId, percentage_basis_points: u32,
+    );
 }

--- a/workspace/apps/perpetuals/contracts/src/core/interface.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/interface.cairo
@@ -138,4 +138,8 @@ pub trait ICore<TContractState> {
     fn force_reset_protection_limit(
         ref self: TContractState, vault_position: PositionId, percentage_basis_points: u32,
     );
+
+    fn update_vault_protection_limit(
+        ref self: TContractState, vault_position: PositionId, limit: u32,
+    );
 }

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests.cairo
@@ -10,3 +10,4 @@ mod unit_flow_tests;
 mod vault_share_deposit_flow_tests;
 
 mod vault_share_tv_tr_impact_tests;
+mod vault_protection_tests;

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests.cairo
@@ -11,3 +11,4 @@ mod vault_share_deposit_flow_tests;
 
 mod vault_share_tv_tr_impact_tests;
 mod vault_protection_tests;
+mod vault_protection_trading_tests;

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/caller_failure_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/caller_failure_tests.cairo
@@ -328,3 +328,11 @@ fn test_activate_new_component_only_upgrade_governor() {
             component_type: 'TRANSFERS', component_address: 'SOME_HASH'.try_into().unwrap(),
         );
 }
+
+#[test]
+#[should_panic(expected: "ONLY_APP_GOVERNOR")]
+fn test_force_reset_protection_limit_only_app_governor() {
+    let (_, contract_address) = setup();
+    let dispatcher = ICoreDispatcher { contract_address };
+    dispatcher.force_reset_protection_limit(vault_position: POSITION_ID_1, percentage_basis_points: 0);
+}

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/caller_failure_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/caller_failure_tests.cairo
@@ -334,5 +334,13 @@ fn test_activate_new_component_only_upgrade_governor() {
 fn test_force_reset_protection_limit_only_app_governor() {
     let (_, contract_address) = setup();
     let dispatcher = ICoreDispatcher { contract_address };
-    dispatcher.force_reset_protection_limit(vault_position: POSITION_ID_1, percentage_basis_points: 0);
+    dispatcher
+        .force_reset_protection_limit(vault_position: POSITION_ID_1, percentage_basis_points: 0);
+}
+#[test]
+#[should_panic(expected: "ONLY_APP_GOVERNOR")]
+fn test_update_vault_protection_limit_only_app_governor() {
+    let (_, contract_address) = setup();
+    let dispatcher = ICoreDispatcher { contract_address };
+    dispatcher.update_vault_protection_limit(vault_position: POSITION_ID_1, limit: 0);
 }

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/perps_tests_facade.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/perps_tests_facade.cairo
@@ -1900,6 +1900,11 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
         ICoreDispatcher { contract_address: self.perpetuals_contract }
             .force_reset_protection_limit(:vault_position, :percentage_basis_points);
     }
+
+    fn update_vault_protection_limit(ref self: PerpsTestsFacade, vault_position: PositionId, limit: u32) {
+        self.set_app_governor_as_caller();
+        ICoreDispatcher { contract_address: self.perpetuals_contract }.update_vault_protection_limit(:vault_position, :limit);
+    }
 }
 
 

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/perps_tests_facade.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/perps_tests_facade.cairo
@@ -1888,6 +1888,10 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
             asset_id: vault.asset_id,
         }
     }
+
+    fn advance_time(ref self: PerpsTestsFacade, seconds: u64) {
+        advance_time(seconds);
+    }
 }
 
 

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/perps_tests_facade.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/perps_tests_facade.cairo
@@ -1892,6 +1892,14 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
     fn advance_time(ref self: PerpsTestsFacade, seconds: u64) {
         advance_time(seconds);
     }
+
+    fn force_reset_protection_limit(
+        ref self: PerpsTestsFacade, vault_position: PositionId, percentage_basis_points: u32,
+    ) {
+        self.set_app_governor_as_caller();
+        ICoreDispatcher { contract_address: self.perpetuals_contract }
+            .force_reset_protection_limit(:vault_position, :percentage_basis_points);
+    }
 }
 
 

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/procotol_vault_redeem_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/procotol_vault_redeem_tests.cairo
@@ -17,7 +17,7 @@ fn test_redeem_from_protocol_vault_redeem_to_same_position() {
     let redeeming_user = state.new_user_with_position();
     let vault_init_deposit = state
         .facade
-        .deposit(vault_user.account, vault_user.position_id, 5000_u64);
+        .deposit(vault_user.account, vault_user.position_id, 50000_u64);
     state.facade.process_deposit(vault_init_deposit);
     let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
     state.facade.price_tick(@vault_config.asset_info, 1);
@@ -141,7 +141,7 @@ fn test_redeem_from_protocol_vault_redeem_to_same_position_with_9pct_premium() {
     let redeeming_user = state.new_user_with_position();
     let vault_init_deposit = state
         .facade
-        .deposit(vault_user.account, vault_user.position_id, 5000_u64);
+        .deposit(vault_user.account, vault_user.position_id, 50000_u64);
     state.facade.process_deposit(vault_init_deposit);
     let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
     state.facade.price_tick(@vault_config.asset_info, 1);
@@ -268,7 +268,7 @@ fn test_redeem_from_protocol_vault_redeem_to_same_position_is_rejected_with_11pc
     let redeeming_user = state.new_user_with_position();
     let vault_init_deposit = state
         .facade
-        .deposit(vault_user.account, vault_user.position_id, 5000_u64);
+        .deposit(vault_user.account, vault_user.position_id, 50000_u64);
     state.facade.process_deposit(vault_init_deposit);
     let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
     state.facade.price_tick(@vault_config.asset_info, 1);
@@ -314,7 +314,7 @@ fn test_redeem_from_protocol_vault_impacts_price_as_expected() {
     let redeeming_user = state.new_user_with_position();
     let vault_init_deposit = state
         .facade
-        .deposit(vault_user.account, vault_user.position_id, 5000_u64);
+        .deposit(vault_user.account, vault_user.position_id, 50000_u64);
     state.facade.process_deposit(vault_init_deposit);
     let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
     state.facade.price_tick(@vault_config.asset_info, 1);
@@ -322,7 +322,7 @@ fn test_redeem_from_protocol_vault_impacts_price_as_expected() {
     state
         .facade
         .process_deposit(
-            state.facade.deposit(redeeming_user.account, redeeming_user.position_id, 1000_u64),
+            state.facade.deposit(redeeming_user.account, redeeming_user.position_id, 9000_u64),
         );
 
     state
@@ -332,7 +332,7 @@ fn test_redeem_from_protocol_vault_impacts_price_as_expected() {
                 .facade
                 .deposit_into_vault(
                     vault: vault_config,
-                    amount_to_invest: 1000,
+                    amount_to_invest: 9000,
                     min_shares_to_receive: 500,
                     depositing_user: redeeming_user,
                     receiving_user: redeeming_user,
@@ -344,7 +344,7 @@ fn test_redeem_from_protocol_vault_impacts_price_as_expected() {
         .erc4626
         .preview_redeem(1000_u256);
 
-    const value_of_shares: u64 = 439;
+    const value_of_shares: u64 = 2940;
 
     state
         .facade
@@ -352,11 +352,11 @@ fn test_redeem_from_protocol_vault_impacts_price_as_expected() {
             vault: vault_config,
             withdrawing_user: redeeming_user,
             receiving_user: redeeming_user,
-            shares_to_burn_user: 400,
+            shares_to_burn_user: 2840,
             value_of_shares_user: value_of_shares,
-            shares_to_burn_vault: 400,
+            shares_to_burn_vault: 2840,
             value_of_shares_vault: value_of_shares,
-            actual_shares_user: 400,
+            actual_shares_user: 2840,
             actual_collateral_user: value_of_shares,
         );
 
@@ -366,7 +366,7 @@ fn test_redeem_from_protocol_vault_impacts_price_as_expected() {
         .preview_redeem(1000_u256);
 
     assert_with_error(
-        value_of_1000_shares_after_withdrawal == value_of_1000_shares_before_withdrawal - 7,
+        value_of_1000_shares_after_withdrawal == value_of_1000_shares_before_withdrawal - 2,
         format!(
             "value of 1000 shares did not decrease after withdrawal, before: {}, after: {}",
             value_of_1000_shares_before_withdrawal,
@@ -383,7 +383,7 @@ fn test_redeem_from_protocol_vault_unfair__user_redeem() {
     let redeeming_user = state.new_user_with_position_id(555_u32.into());
     let vault_init_deposit = state
         .facade
-        .deposit(vault_user.account, vault_user.position_id, 5000_u64);
+        .deposit(vault_user.account, vault_user.position_id, 50000_u64);
     state.facade.process_deposit(vault_init_deposit);
     let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
     state.facade.price_tick(@vault_config.asset_info, 1);
@@ -433,7 +433,7 @@ fn test_redeem_from_protocol_vault_unfair__vault_redeem() {
     let redeeming_user = state.new_user_with_position_id(555_u32.into());
     let vault_init_deposit = state
         .facade
-        .deposit(vault_user.account, vault_user.position_id, 5000_u64);
+        .deposit(vault_user.account, vault_user.position_id, 50000_u64);
     state.facade.process_deposit(vault_init_deposit);
     let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
     state.facade.price_tick(@vault_config.asset_info, 1);
@@ -484,7 +484,7 @@ fn test_redeem_from_protocol_vault_over_fulfilled_user() {
     let redeeming_user = state.new_user_with_position_id(555_u32.into());
     let vault_init_deposit = state
         .facade
-        .deposit(vault_user.account, vault_user.position_id, 5000_u64);
+        .deposit(vault_user.account, vault_user.position_id, 50000_u64);
     state.facade.process_deposit(vault_init_deposit);
     let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
     state.facade.price_tick(@vault_config.asset_info, 1);
@@ -536,7 +536,7 @@ fn test_redeem_from_protocol_vault_over_fulfilled_vault() {
     let redeeming_user = state.new_user_with_position_id(555_u32.into());
     let vault_init_deposit = state
         .facade
-        .deposit(vault_user.account, vault_user.position_id, 5000_u64);
+        .deposit(vault_user.account, vault_user.position_id, 50000_u64);
     state.facade.process_deposit(vault_init_deposit);
     let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
     state.facade.price_tick(@vault_config.asset_info, 1);
@@ -588,7 +588,7 @@ fn test_redeem_from_protocol_vault_allows_redeem_when_improving_tv_tr() {
     let redeeming_user = state.new_user_with_position_id(555_u32.into());
     let vault_init_deposit = state
         .facade
-        .deposit(vault_user.account, vault_user.position_id, 5000_u64);
+        .deposit(vault_user.account, vault_user.position_id, 50000_u64);
     state.facade.process_deposit(vault_init_deposit);
     let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
 
@@ -716,7 +716,7 @@ fn test_redeem_from_protocol_vault_fails_redeem_when_worsening_tv_tr() {
     let redeeming_user = state.new_user_with_position_id(555_u32.into());
     let vault_init_deposit = state
         .facade
-        .deposit(vault_user.account, vault_user.position_id, 5000_u64);
+        .deposit(vault_user.account, vault_user.position_id, 50000_u64);
     state.facade.process_deposit(vault_init_deposit);
     let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
 
@@ -842,7 +842,7 @@ fn test_liquidate_vault_shares_succeeds_when_improving_tv_tr() {
     let redeeming_user = state.new_user_with_position_id(555_u32.into());
     let vault_init_deposit = state
         .facade
-        .deposit(vault_user.account, vault_user.position_id, 5000_u64);
+        .deposit(vault_user.account, vault_user.position_id, 50000_u64);
     state.facade.process_deposit(vault_init_deposit);
     let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
 
@@ -963,7 +963,7 @@ fn test_liquidate_vault_shares_succeeds_when_improving_tv_tr_starting_with_negat
     let redeeming_user = state.new_user_with_position_id(555_u32.into());
     let vault_init_deposit = state
         .facade
-        .deposit(vault_user.account, vault_user.position_id, 5000_u64);
+        .deposit(vault_user.account, vault_user.position_id, 50000_u64);
     state.facade.process_deposit(vault_init_deposit);
     let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
 
@@ -1087,7 +1087,7 @@ fn test_liquidate_vault_shares_fails_when_not_improving_tv_tr_starting_with_nega
     let redeeming_user = state.new_user_with_position_id(555_u32.into());
     let vault_init_deposit = state
         .facade
-        .deposit(vault_user.account, vault_user.position_id, 5000_u64);
+        .deposit(vault_user.account, vault_user.position_id, 50000_u64);
     state.facade.process_deposit(vault_init_deposit);
     let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
 
@@ -1212,7 +1212,7 @@ fn test_liquidate_vault_shares_fails_when_worsening_tv_tr() {
     let redeeming_user = state.new_user_with_position_id(555_u32.into());
     let vault_init_deposit = state
         .facade
-        .deposit(vault_user.account, vault_user.position_id, 5000_u64);
+        .deposit(vault_user.account, vault_user.position_id, 50000_u64);
     state.facade.process_deposit(vault_init_deposit);
     let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
 
@@ -1333,7 +1333,7 @@ fn test_withdraw_cannot_be_called_except_by_perps_contract() {
     let receiving_user = state.new_user_with_position();
     let vault_init_deposit = state
         .facade
-        .deposit(vault_user.account, vault_user.position_id, 5000_u64);
+        .deposit(vault_user.account, vault_user.position_id, 50000_u64);
     state.facade.process_deposit(vault_init_deposit);
     let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
 
@@ -1354,7 +1354,7 @@ fn test_redeem_cannot_be_called_except_by_perps_contract() {
     let receiving_user = state.new_user_with_position();
     let vault_init_deposit = state
         .facade
-        .deposit(vault_user.account, vault_user.position_id, 5000_u64);
+        .deposit(vault_user.account, vault_user.position_id, 50000_u64);
     state.facade.process_deposit(vault_init_deposit);
     let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
 

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/vault_protection_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/vault_protection_tests.cairo
@@ -1,0 +1,413 @@
+use core::num::traits::Bounded;
+use perpetuals::tests::constants::*;
+use perpetuals::tests::flow_tests::infra::*;
+use perpetuals::tests::flow_tests::perps_tests_facade::*;
+use super::perps_tests_facade::PerpsTestsFacadeTrait;
+
+pub const MAX_U128: u128 = Bounded::<u128>::MAX;
+
+#[test]
+#[should_panic(
+    expected: "Vault Protection Limit Exceeded, tv_at_last_check: 60000, tv_after_operation: 56999, max_allowed_loss : 3000",
+)]
+fn test_redeem_exceeding_5_percent_limit_fails() {
+    let mut state: FlowTestBase = FlowTestBaseTrait::new();
+    let vault_user = state.new_user_with_position();
+    let redeeming_user = state.new_user_with_position();
+
+    // Initial deposit to vault: 50,000 USDC
+    let vault_init_deposit = state
+        .facade
+        .deposit(vault_user.account, vault_user.position_id, 50000_u64);
+    state.facade.process_deposit(vault_init_deposit);
+    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    state.facade.price_tick(@vault_config.asset_info, 1);
+
+    state
+        .facade
+        .process_deposit(
+            state.facade.deposit(redeeming_user.account, redeeming_user.position_id, 10000_u64),
+        );
+
+    state
+        .facade
+        .process_deposit(
+            state
+                .facade
+                .deposit_into_vault(
+                    vault: vault_config,
+                    amount_to_invest: 10000,
+                    min_shares_to_receive: 5000,
+                    depositing_user: redeeming_user,
+                    receiving_user: redeeming_user,
+                ),
+        );
+
+    //trigger loading of TV and setting the limit
+    state
+        .facade
+        .redeem_from_vault(
+            vault: vault_config,
+            withdrawing_user: redeeming_user,
+            receiving_user: redeeming_user,
+            shares_to_burn_user: 1,
+            value_of_shares_user: 1,
+            shares_to_burn_vault: 1,
+            value_of_shares_vault: 1,
+            actual_shares_user: 1,
+            actual_collateral_user: 1,
+        );
+
+    let shares_to_burn: u64 = 3000;
+    let value_of_shares: u64 = 3000;
+
+    state
+        .facade
+        .redeem_from_vault(
+            vault: vault_config,
+            withdrawing_user: redeeming_user,
+            receiving_user: redeeming_user,
+            shares_to_burn_user: shares_to_burn,
+            value_of_shares_user: value_of_shares,
+            shares_to_burn_vault: shares_to_burn,
+            value_of_shares_vault: value_of_shares,
+            actual_shares_user: shares_to_burn,
+            actual_collateral_user: value_of_shares,
+        );
+}
+
+#[test]
+#[should_panic(
+    expected: "Vault Protection Limit Exceeded, tv_at_last_check: 60000, tv_after_operation: 56999, max_allowed_loss : 3000",
+)]
+fn test_multiple_redeems_cumulative_failure() {
+    let mut state: FlowTestBase = FlowTestBaseTrait::new();
+    let vault_user = state.new_user_with_position();
+    let redeeming_user = state.new_user_with_position();
+
+    // Initial deposit to vault: 50,000 USDC
+    let vault_init_deposit = state
+        .facade
+        .deposit(vault_user.account, vault_user.position_id, 50000_u64);
+    state.facade.process_deposit(vault_init_deposit);
+    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    state.facade.price_tick(@vault_config.asset_info, 1);
+
+    // Redeeming user deposits 10,000 USDC to invest
+    state
+        .facade
+        .process_deposit(
+            state.facade.deposit(redeeming_user.account, redeeming_user.position_id, 10000_u64),
+        );
+
+    // Invest 10,000 USDC into vault
+    state
+        .facade
+        .process_deposit(
+            state
+                .facade
+                .deposit_into_vault(
+                    vault: vault_config,
+                    amount_to_invest: 10000,
+                    min_shares_to_receive: 5000,
+                    depositing_user: redeeming_user,
+                    receiving_user: redeeming_user,
+                ),
+        );
+
+    // trigger loading of TV and setting the limit
+    state
+        .facade
+        .redeem_from_vault(
+            vault: vault_config,
+            withdrawing_user: redeeming_user,
+            receiving_user: redeeming_user,
+            shares_to_burn_user: 1,
+            value_of_shares_user: 1,
+            shares_to_burn_vault: 1,
+            value_of_shares_vault: 1,
+            actual_shares_user: 1,
+            actual_collateral_user: 1,
+        );
+
+    // Baseline TV = 60000. Limit = 3000 loss.
+
+    // 1st redeem: 1500 USDC (ok)
+    state
+        .facade
+        .redeem_from_vault(
+            vault: vault_config,
+            withdrawing_user: redeeming_user,
+            receiving_user: redeeming_user,
+            shares_to_burn_user: 1500,
+            value_of_shares_user: 1500,
+            shares_to_burn_vault: 1500,
+            value_of_shares_vault: 1500,
+            actual_shares_user: 1500,
+            actual_collateral_user: 1500,
+        );
+
+    // 2nd redeem: 1498 USDC (ok, total = 2999)
+    state
+        .facade
+        .redeem_from_vault(
+            vault: vault_config,
+            withdrawing_user: redeeming_user,
+            receiving_user: redeeming_user,
+            shares_to_burn_user: 1498,
+            value_of_shares_user: 1498,
+            shares_to_burn_vault: 1498,
+            value_of_shares_vault: 1498,
+            actual_shares_user: 1498,
+            actual_collateral_user: 1498,
+        );
+
+    // 3rd redeem: 2 USDC (should fail, total would be 3001)
+    state
+        .facade
+        .redeem_from_vault(
+            vault: vault_config,
+            withdrawing_user: redeeming_user,
+            receiving_user: redeeming_user,
+            shares_to_burn_user: 2,
+            value_of_shares_user: 2,
+            shares_to_burn_vault: 2,
+            value_of_shares_vault: 2,
+            actual_shares_user: 2,
+            actual_collateral_user: 2,
+        );
+}
+
+#[test]
+fn test_reset_after_24h() {
+    let mut state: FlowTestBase = FlowTestBaseTrait::new();
+    let vault_user = state.new_user_with_position();
+    let redeeming_user = state.new_user_with_position();
+
+    let vault_init_deposit = state
+        .facade
+        .deposit(vault_user.account, vault_user.position_id, 50000_u64);
+    state.facade.process_deposit(vault_init_deposit);
+    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    state.facade.price_tick(@vault_config.asset_info, 1);
+
+    state
+        .facade
+        .process_deposit(
+            state.facade.deposit(redeeming_user.account, redeeming_user.position_id, 10000_u64),
+        );
+
+    state
+        .facade
+        .process_deposit(
+            state
+                .facade
+                .deposit_into_vault(
+                    vault: vault_config,
+                    amount_to_invest: 10000,
+                    min_shares_to_receive: 5000,
+                    depositing_user: redeeming_user,
+                    receiving_user: redeeming_user,
+                ),
+        );
+
+    // trigger loading of TV and setting the limit
+    state
+        .facade
+        .redeem_from_vault(
+            vault: vault_config,
+            withdrawing_user: redeeming_user,
+            receiving_user: redeeming_user,
+            shares_to_burn_user: 1,
+            value_of_shares_user: 1,
+            shares_to_burn_vault: 1,
+            value_of_shares_vault: 1,
+            actual_shares_user: 1,
+            actual_collateral_user: 1,
+        );
+
+    // Baseline TV = 60000. Limit = 3000 loss.
+    // Redeem 2900 USDC (ok)
+    state
+        .facade
+        .redeem_from_vault(
+            vault: vault_config,
+            withdrawing_user: redeeming_user,
+            receiving_user: redeeming_user,
+            shares_to_burn_user: 2900,
+            value_of_shares_user: 2900,
+            shares_to_burn_vault: 2900,
+            value_of_shares_vault: 2900,
+            actual_shares_user: 2900,
+            actual_collateral_user: 2900,
+        );
+
+    // Wait another 24h+
+    state.facade.advance_time(86401);
+    state.facade.price_tick(@vault_config.asset_info, 1);
+    state.facade.funding_tick(array![].span());
+    // Now baseline should be ~57100. New limit ~2855.
+    // Redeem another 2000 USDC (should be ok)
+    state
+        .facade
+        .redeem_from_vault(
+            vault: vault_config,
+            withdrawing_user: redeeming_user,
+            receiving_user: redeeming_user,
+            shares_to_burn_user: 2000,
+            value_of_shares_user: 2000,
+            shares_to_burn_vault: 2000,
+            value_of_shares_vault: 2000,
+            actual_shares_user: 2000,
+            actual_collateral_user: 2000,
+        );
+}
+
+#[test]
+fn test_profit_does_not_reset_baseline_until_24h_pass() {
+    let mut state: FlowTestBase = FlowTestBaseTrait::new();
+    let vault_user = state.new_user_with_position();
+    let redeeming_user = state.new_user_with_position();
+
+    let vault_init_deposit = state
+        .facade
+        .deposit(vault_user.account, vault_user.position_id, 50000_u64);
+    state.facade.process_deposit(vault_init_deposit);
+    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    state.facade.price_tick(@vault_config.asset_info, 1);
+
+    state
+        .facade
+        .process_deposit(
+            state.facade.deposit(redeeming_user.account, redeeming_user.position_id, 10000_u64),
+        );
+
+    state
+        .facade
+        .process_deposit(
+            state
+                .facade
+                .deposit_into_vault(
+                    vault: vault_config,
+                    amount_to_invest: 10000,
+                    min_shares_to_receive: 5000,
+                    depositing_user: redeeming_user,
+                    receiving_user: redeeming_user,
+                ),
+        );
+
+    // trigger loading of TV and setting the limit
+    state
+        .facade
+        .redeem_from_vault(
+            vault: vault_config,
+            withdrawing_user: redeeming_user,
+            receiving_user: redeeming_user,
+            shares_to_burn_user: 1,
+            value_of_shares_user: 1,
+            shares_to_burn_vault: 1,
+            value_of_shares_vault: 1,
+            actual_shares_user: 1,
+            actual_collateral_user: 1,
+        );
+
+    state
+        .facade
+        .process_deposit(
+            state.facade.deposit(vault_user.account, vault_user.position_id, 10000_u64),
+        );
+
+    //vault has 69999, but last check was at 60000
+    // limit is be 3000, but we have additional 10000
+    // redeem up to 12999 should succeed
+    state
+        .facade
+        .redeem_from_vault(
+            vault: vault_config,
+            withdrawing_user: redeeming_user,
+            receiving_user: redeeming_user,
+            shares_to_burn_user: 9000,
+            value_of_shares_user: 9000,
+            shares_to_burn_vault: 9000,
+            value_of_shares_vault: 9000,
+            actual_shares_user: 9000,
+            actual_collateral_user: 9000,
+        );
+}
+
+#[test]
+#[should_panic(
+    expected: "Vault Protection Limit Exceeded, tv_at_last_check: 70000, tv_after_operation: 66499, max_allowed_loss : 3500",
+)]
+fn test_profit_then_redeem_over_limit_fails() {
+    let mut state: FlowTestBase = FlowTestBaseTrait::new();
+    let vault_user = state.new_user_with_position();
+    let redeeming_user = state.new_user_with_position();
+
+    let vault_init_deposit = state
+        .facade
+        .deposit(vault_user.account, vault_user.position_id, 50000_u64);
+    state.facade.process_deposit(vault_init_deposit);
+    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    state.facade.price_tick(@vault_config.asset_info, 1);
+
+    state
+        .facade
+        .process_deposit(
+            state.facade.deposit(redeeming_user.account, redeeming_user.position_id, 20000_u64),
+        );
+
+    state
+        .facade
+        .process_deposit(
+            state
+                .facade
+                .deposit_into_vault(
+                    vault: vault_config,
+                    amount_to_invest: 20000,
+                    min_shares_to_receive: 5000,
+                    depositing_user: redeeming_user,
+                    receiving_user: redeeming_user,
+                ),
+        );
+
+    // trigger loading of TV and setting the limit
+    state
+        .facade
+        .redeem_from_vault(
+            vault: vault_config,
+            withdrawing_user: redeeming_user,
+            receiving_user: redeeming_user,
+            shares_to_burn_user: 1,
+            value_of_shares_user: 1,
+            shares_to_burn_vault: 1,
+            value_of_shares_vault: 1,
+            actual_shares_user: 1,
+            actual_collateral_user: 1,
+        );
+
+    // Baseline TV = 70000. Limit = 3500 loss.
+    // Profit 10000. TV = 80000.
+    state
+        .facade
+        .process_deposit(
+            state.facade.deposit(vault_user.account, vault_user.position_id, 10000_u64),
+        );
+
+    // Redeem 13501.
+    // Delta = 80000 - 13501 - 70000 = -3501.
+    // Loss = 3501. Limit = 3500. Should fail.
+    state
+        .facade
+        .redeem_from_vault(
+            vault: vault_config,
+            withdrawing_user: redeeming_user,
+            receiving_user: redeeming_user,
+            shares_to_burn_user: 13500,
+            value_of_shares_user: 13500,
+            shares_to_burn_vault: 13500,
+            value_of_shares_vault: 13500,
+            actual_shares_user: 13500,
+            actual_collateral_user: 13500,
+        );
+}

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/vault_protection_trading_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/vault_protection_trading_tests.cairo
@@ -1,0 +1,182 @@
+use perpetuals::tests::flow_tests::infra::*;
+use perpetuals::tests::flow_tests::perps_tests_facade::*;
+use starkware_utils::constants::MAX_U128;
+use super::perps_tests_facade::PerpsTestsFacadeTrait;
+
+
+#[test]
+#[should_panic(
+    expected: "Vault Protection Limit Exceeded, tv_at_last_check: 10000, tv_after_operation: 5000, max_allowed_loss : 500",
+)]
+fn test_trading_loss_activates_protection() {
+    let mut state: FlowTestBase = FlowTestBaseTrait::new();
+    let vault_user = state.new_user_with_position();
+    let trader_user = state.new_user_with_position();
+
+    // 1. Setup Vault
+    // Deposit 100k USDC
+    state
+        .facade
+        .process_deposit(
+            state.facade.deposit(vault_user.account, vault_user.position_id, 10000_u64),
+        );
+    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+
+    // 2. Setup Trader
+    // Deposit 100k USDC
+    state
+        .facade
+        .process_deposit(
+            state.facade.deposit(trader_user.account, trader_user.position_id, 10000_u64),
+        );
+
+    // 3. Establish Baseline
+    // Advance 24h+ to allow baseline check
+    state.facade.advance_time(86401);
+    state.facade.funding_tick(array![].span());
+
+    let risk_factor_data = RiskFactorTiers {
+        tiers: array![10].span(), first_tier_boundary: MAX_U128, tier_size: 1,
+    };
+    let synthetic_info = SyntheticInfoTrait::new(
+        asset_name: 'BTC_1', :risk_factor_data, oracles_len: 1,
+    );
+    let asset_id = synthetic_info.asset_id;
+    state.facade.add_active_synthetic(synthetic_info: @synthetic_info, initial_price: 100);
+    state.facade.price_tick(@vault_config.asset_info, 1);
+    state.facade.price_tick(@synthetic_info, 100);
+
+    // 4. Executing Trade
+    // Trader Longs 100 BTC, Vault Shorts 100 BTC (via matching)
+    let order_trader = state
+        .facade
+        .create_order(
+            user: trader_user,
+            base_amount: 100,
+            base_asset_id: asset_id,
+            quote_amount: -10000,
+            fee_amount: 0,
+        );
+
+    let order_vault = state
+        .facade
+        .create_order(
+            user: vault_user,
+            base_amount: -100,
+            base_asset_id: asset_id,
+            quote_amount: 10000,
+            fee_amount: 0,
+        );
+
+    state.facade.trade(order_trader, order_vault, 100, -10000, 0, 0);
+
+    // now the opposite, but price is now 150 per BTC (short vault make loss of 100 * 50 = 5000)
+    let order_trader_inverse = state
+        .facade
+        .create_order(
+            user: trader_user,
+            base_amount: -100,
+            base_asset_id: asset_id,
+            quote_amount: 15000,
+            fee_amount: 0,
+        );
+
+    let order_vault_inverse = state
+        .facade
+        .create_order(
+            user: vault_user,
+            base_amount: 100,
+            base_asset_id: asset_id,
+            quote_amount: -15000,
+            fee_amount: 0,
+        );
+
+    state.facade.trade(order_trader_inverse, order_vault_inverse, -100, 15000, 0, 0);
+}
+
+#[test]
+fn test_trading_loss_within_limit() {
+    let mut state: FlowTestBase = FlowTestBaseTrait::new();
+    let vault_user = state.new_user_with_position();
+    let trader_user = state.new_user_with_position();
+
+    // 1. Setup Vault
+    // Deposit 100k USDC
+    state
+        .facade
+        .process_deposit(
+            state.facade.deposit(vault_user.account, vault_user.position_id, 10000_u64),
+        );
+    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+
+    // 2. Setup Trader
+    // Deposit 100k USDC
+    state
+        .facade
+        .process_deposit(
+            state.facade.deposit(trader_user.account, trader_user.position_id, 10000_u64),
+        );
+
+    // 3. Establish Baseline
+    // Advance 24h+ to allow baseline check
+    state.facade.advance_time(86401);
+    state.facade.funding_tick(array![].span());
+
+    let risk_factor_data = RiskFactorTiers {
+        tiers: array![10].span(), first_tier_boundary: MAX_U128, tier_size: 1,
+    };
+    let synthetic_info = SyntheticInfoTrait::new(
+        asset_name: 'BTC_1', :risk_factor_data, oracles_len: 1,
+    );
+    let asset_id = synthetic_info.asset_id;
+    state.facade.add_active_synthetic(synthetic_info: @synthetic_info, initial_price: 100);
+    state.facade.price_tick(@vault_config.asset_info, 1);
+    state.facade.price_tick(@synthetic_info, 100);
+
+    // 4. Executing Trade
+    // Trader Longs 100 BTC, Vault Shorts 100 BTC (via matching)
+    let order_trader = state
+        .facade
+        .create_order(
+            user: trader_user,
+            base_amount: 100,
+            base_asset_id: asset_id,
+            quote_amount: -10000,
+            fee_amount: 0,
+        );
+
+    let order_vault = state
+        .facade
+        .create_order(
+            user: vault_user,
+            base_amount: -100,
+            base_asset_id: asset_id,
+            quote_amount: 10000,
+            fee_amount: 0,
+        );
+
+    state.facade.trade(order_trader, order_vault, 100, -10000, 0, 0);
+
+    // now the opposite, but price is now 150 per BTC (short vault make loss of 10 * 50 = 500)
+    let order_trader_inverse = state
+        .facade
+        .create_order(
+            user: trader_user,
+            base_amount: -100,
+            base_asset_id: asset_id,
+            quote_amount: 10100,
+            fee_amount: 0,
+        );
+
+    let order_vault_inverse = state
+        .facade
+        .create_order(
+            user: vault_user,
+            base_amount: 100,
+            base_asset_id: asset_id,
+            quote_amount: -10100,
+            fee_amount: 0,
+        );
+
+    state.facade.trade(order_trader_inverse, order_vault_inverse, -100, 10100, 0, 0);
+}


### PR DESCRIPTION
# PR: Implement Vault Protection Mechanism

## Summary
This PR introduces a new safety mechanism designed to protect vaults from experiencing large reductions in Total Value (TV) within a short timeframe. The protection limit is set to **5% of the vault's TV over a 24-hour period**.

## 🛡️ Vault Protection Mechanism

### Core Parameters
- **Check Frequency**: 24 hours (`86,400` seconds).
- **Max Allowed Loss**: 5% of the baseline TV recorded at the start of each period.

### 🚀 Enforcement Areas
The protection mechanism is integrated into all major operations that could significantly impact a vault's TV:

| Component | Target Position | Enforcement Context |
| :--- | :--- | :--- |
| **Core** | Order A & Order B | Applied during atomic trade matches if either party is a vault. |
| **Vaults Manager** | Vault Position | Enforced during `RedeemVaultShares`. |
| **Liquidation Manager** | Liquidator | Enforced when a vault acts as a liquidator. |
| **Deleverage Manager** | Deleverager | Enforced when a vault acts as a deleverager. |

### Implementation Details

#### 🧱 Data Model & Management
- **`types.cairo`**: Updated `VaultConfig` to track `last_tv_check`, `tv_at_check` (baseline), and `max_tv_loss`.
- **`vaults.cairo`**: Implemented `get_vault_protection_config` to lazily update the baseline TV and loss limit every 24 hours.

#### ⚖️ Enforcement logic
- **`positions.cairo`**: Integrated protection checks into `validate_healthy_or_healthier_position`. Operations that would cause a vault to exceed its 5% loss limit will now panic with a detailed error.

#### 🚫 Restrictions
To prevent bypasses of the protection mechanism:
- Standard withdrawals via `WithdrawalManager` are now **blocked** for vault positions.
- Direct transfers via `TransferManager` are **blocked** for vault positions.

## 📊 Changes Breakdown

### Core Components
- `workspace/apps/perpetuals/contracts/src/core/components/vaults/types.cairo`: Added protection fields to `VaultConfig`.
- `workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults.cairo`: Added baseline management logic.
- `workspace/apps/perpetuals/contracts/src/core/components/positions/positions.cairo`: Added enforcement check.
- `workspace/apps/perpetuals/contracts/src/core/components/vaults/events.cairo`: Added `LiquidateVaultShares` and `RedeemVaultShares` events.

### Tests
- `workspace/apps/perpetuals/contracts/src/tests/flow_tests/procotol_vault_redeem_tests.cairo`: Updated with larger scale tests to validate protection boundaries.
