### PR TITLE
[Feature] - Prediction Market Deposits

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/components/external_components/external_component_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/external_components/external_component_manager.cairo
@@ -19,7 +19,8 @@ pub mod ExternalComponents {
     use crate::core::components::deposit::deposit_manager::IDepositExternalLibraryDispatcher;
     use crate::core::components::external_components::events;
     use crate::core::components::external_components::interface::{
-        EXTERNAL_COMPONENT_DELEVERAGES, EXTERNAL_COMPONENT_FORCED_REQUESTS, IExternalComponents,
+        EXTERNAL_COMPONENT_DELEVERAGES, EXTERNAL_COMPONENT_FORCED_REQUESTS,
+        EXTERNAL_COMPONENT_PREDICTIONS, IExternalComponents,
     };
     use crate::core::components::external_components::named_component::ITypedComponentLibraryDispatcher;
     use crate::core::components::forced_requests::forced_requests_manager::IForcedRequestsManagerLibraryDispatcher;
@@ -27,6 +28,7 @@ pub mod ExternalComponents {
     use crate::core::components::transfer::transfer_manager::ITransferManagerLibraryDispatcher;
     use crate::core::components::vaults::vaults_contract::IVaultExternalLibraryDispatcher;
     use crate::core::components::withdrawal::withdrawal_manager::IWithdrawalManagerLibraryDispatcher;
+    use perpetuals::predictions::predictions::IPredictionsLibraryDispatcher;
     use super::super::interface::{
         EXTERNAL_COMPONENT_ASSETS, EXTERNAL_COMPONENT_DEPOSITS, EXTERNAL_COMPONENT_LIQUIDATIONS,
         EXTERNAL_COMPONENT_TRANSFERS, EXTERNAL_COMPONENT_VAULT, EXTERNAL_COMPONENT_WITHDRAWALS,
@@ -172,6 +174,17 @@ pub mod ExternalComponents {
             assert(class_hash.is_non_zero(), 'NO_FORCED_REQUESTS_MANAGER');
             IForcedRequestsManagerLibraryDispatcher { class_hash: class_hash }
         }
+
+        fn _get_predictions_dispatcher(
+            ref self: ComponentState<TContractState>,
+        ) -> IPredictionsLibraryDispatcher {
+            let class_hash = self
+                .external_component_implementations
+                .entry(EXTERNAL_COMPONENT_PREDICTIONS)
+                .read();
+            assert(class_hash.is_non_zero(), 'NO_PREDICTIONS_MANAGER');
+            IPredictionsLibraryDispatcher { class_hash: class_hash }
+        }
     }
 
     #[generate_trait]
@@ -211,7 +224,8 @@ pub mod ExternalComponents {
                 || (component_type == EXTERNAL_COMPONENT_LIQUIDATIONS)
                 || (component_type == EXTERNAL_COMPONENT_DELEVERAGES)
                 || (component_type == EXTERNAL_COMPONENT_ASSETS)
-                || (component_type == EXTERNAL_COMPONENT_FORCED_REQUESTS) {
+                || (component_type == EXTERNAL_COMPONENT_FORCED_REQUESTS)
+                || (component_type == EXTERNAL_COMPONENT_PREDICTIONS) {
                 let now = Time::now();
                 let activation_time = now.add(update_delay);
                 let entry = self.registered_external_components.entry(component_type);

--- a/workspace/apps/perpetuals/contracts/src/core/components/external_components/interface.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/external_components/interface.cairo
@@ -9,6 +9,7 @@ pub const EXTERNAL_COMPONENT_DELEVERAGES: felt252 = 'DELEVERAGES';
 pub const EXTERNAL_COMPONENT_DEPOSITS: felt252 = 'DEPOSITS';
 pub const EXTERNAL_COMPONENT_ASSETS: felt252 = 'ASSETS';
 pub const EXTERNAL_COMPONENT_FORCED_REQUESTS: felt252 = 'FORCED_REQUESTS';
+pub const EXTERNAL_COMPONENT_PREDICTIONS: felt252 = 'PREDICTIONS';
 
 #[starknet::interface]
 pub trait IExternalComponents<TContractState> {

--- a/workspace/apps/perpetuals/contracts/src/core/core.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/core.cairo
@@ -18,6 +18,8 @@ pub mod Core {
     use perpetuals::core::components::positions::Positions::{
         FEE_POSITION, InternalTrait as PositionsInternalTrait,
     };
+    use perpetuals::predictions::PredictionPositionsComponent;
+    use perpetuals::predictions::prediction_positions::PredictionPositionsComponent::InternalTrait as PredictionPositionsInternal;
     use perpetuals::core::components::positions::errors::ZERO_MAX_INTEREST_RATE;
     use perpetuals::core::errors::{
         AMOUNT_OVERFLOW, FORCED_WAIT_REQUIRED, INVALID_ZERO_TIMEOUT, LENGTH_MISMATCH,
@@ -93,6 +95,11 @@ pub mod Core {
     );
 
     component!(path: VaultsComponent, storage: vaults, event: VaultsEvent);
+    component!(
+        path: PredictionPositionsComponent,
+        storage: prediction_positions,
+        event: PredictionPositionsEvent,
+    );
 
 
     #[abi(embed_v0)]
@@ -168,6 +175,8 @@ pub mod Core {
         pub external_components: ExternalComponentsComponent::Storage,
         #[substorage(v0)]
         pub vaults: VaultsComponent::Storage,
+        #[substorage(v0)]
+        pub prediction_positions: PredictionPositionsComponent::Storage,
         /// ------- Core -------
         // Forced action parameters:
         // Timelock before forced actions can be executed.
@@ -222,6 +231,8 @@ pub mod Core {
         ExternalComponentsEvent: ExternalComponentsComponent::Event,
         #[flat]
         VaultsEvent: VaultsComponent::Event,
+        #[flat]
+        PredictionPositionsEvent: PredictionPositionsComponent::Event,
         //duplicated for ABI
         Deposit: deposit_events::Deposit,
         DepositCanceled: deposit_events::DepositCanceled,
@@ -1126,6 +1137,67 @@ pub mod Core {
             self.roles.only_app_governor();
             assert(max_interest_rate_per_sec.is_non_zero(), ZERO_MAX_INTEREST_RATE);
             self.positions.max_interest_rate_per_sec.write(max_interest_rate_per_sec);
+        }
+
+        fn create_prediction_account(
+            ref self: ContractState, client_id: felt252, owning_key: felt252,
+        ) {
+            self.prediction_positions.create_account(:client_id, :owning_key);
+        }
+
+        fn deposit_to_prediction_account(
+            ref self: ContractState,
+            operator_nonce: u64,
+            from_position_id: PositionId,
+            client_id: felt252,
+            quantized_amount: u64,
+        ) {
+            self.pausable.assert_not_paused();
+            self.operator_nonce.use_checked_nonce(:operator_nonce);
+
+            let position = self.positions.get_position_mut(position_id: from_position_id);
+
+            let position_diff = PositionDiff {
+                collateral_diff: -(quantized_amount.into()), asset_diff: Option::None,
+            };
+
+            self
+                .positions
+                .validate_healthy_or_healthier_position(
+                    position_id: from_position_id,
+                    position: position.into(),
+                    :position_diff,
+                    tvtr_before: Default::default(),
+                );
+
+            self.positions.apply_diff(position_id: from_position_id, :position_diff);
+
+            let amount = quantized_amount;
+            self.prediction_positions.deposit_collateral(:client_id, :amount);
+        }
+
+        fn withdraw_from_prediction_account(
+            ref self: ContractState,
+            operator_nonce: u64,
+            to_position_id: PositionId,
+            client_id: felt252,
+            quantized_amount: u64,
+        ) {
+            self.pausable.assert_not_paused();
+            self.operator_nonce.use_checked_nonce(:operator_nonce);
+
+            let amount = quantized_amount;
+            self.prediction_positions.withdraw_collateral(:client_id, :amount);
+
+            let position_diff = PositionDiff {
+                collateral_diff: quantized_amount.into(), asset_diff: Option::None,
+            };
+
+            self.positions.apply_diff(position_id: to_position_id, :position_diff);
+        }
+
+        fn get_prediction_collateral(self: @ContractState, client_id: felt252) -> u64 {
+            self.prediction_positions.get_collateral(:client_id)
         }
     }
 

--- a/workspace/apps/perpetuals/contracts/src/core/core.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/core.cairo
@@ -19,7 +19,6 @@ pub mod Core {
         FEE_POSITION, InternalTrait as PositionsInternalTrait,
     };
     use perpetuals::predictions::PredictionPositionsComponent;
-    use perpetuals::predictions::prediction_positions::PredictionPositionsComponent::InternalTrait as PredictionPositionsInternal;
     use perpetuals::core::components::positions::errors::ZERO_MAX_INTEREST_RATE;
     use perpetuals::core::errors::{
         AMOUNT_OVERFLOW, FORCED_WAIT_REQUIRED, INVALID_ZERO_TIMEOUT, LENGTH_MISMATCH,
@@ -71,6 +70,7 @@ pub mod Core {
     use crate::core::components::vaults::vaults::{IVaults, Vaults as VaultsComponent};
     use crate::core::components::vaults::vaults_contract::IVaultExternalDispatcherTrait;
     use crate::core::components::withdrawal::withdrawal_manager::IWithdrawalManagerDispatcherTrait;
+    use perpetuals::predictions::predictions::IPredictionsDispatcherTrait;
     use crate::core::utils::{validate_signature, validate_trade};
 
 
@@ -141,6 +141,10 @@ pub mod Core {
 
     #[abi(embed_v0)]
     impl VaultImpl = VaultsComponent::VaultsImpl<ContractState>;
+
+    #[abi(embed_v0)]
+    impl PredictionPositionsImpl =
+        PredictionPositionsComponent::PredictionPositionsImpl<ContractState>;
 
 
     #[storage]
@@ -1142,63 +1146,52 @@ pub mod Core {
         fn create_prediction_account(
             ref self: ContractState, client_id: felt252, owning_key: felt252,
         ) {
-            self.prediction_positions.create_account(:client_id, :owning_key);
+            self
+                .external_components
+                ._get_predictions_dispatcher()
+                .create_account(:client_id, :owning_key);
         }
 
         fn deposit_to_prediction_account(
             ref self: ContractState,
             operator_nonce: u64,
+            signature: Signature,
             from_position_id: PositionId,
             client_id: felt252,
             quantized_amount: u64,
+            expiration: Timestamp,
+            salt: felt252,
         ) {
             self.pausable.assert_not_paused();
             self.operator_nonce.use_checked_nonce(:operator_nonce);
-
-            let position = self.positions.get_position_mut(position_id: from_position_id);
-
-            let position_diff = PositionDiff {
-                collateral_diff: -(quantized_amount.into()), asset_diff: Option::None,
-            };
-
             self
-                .positions
-                .validate_healthy_or_healthier_position(
-                    position_id: from_position_id,
-                    position: position.into(),
-                    :position_diff,
-                    tvtr_before: Default::default(),
+                .external_components
+                ._get_predictions_dispatcher()
+                .deposit_to_prediction_account(
+                    :signature, :from_position_id, :client_id, :quantized_amount, :expiration, :salt,
                 );
-
-            self.positions.apply_diff(position_id: from_position_id, :position_diff);
-
-            let amount = quantized_amount;
-            self.prediction_positions.deposit_collateral(:client_id, :amount);
         }
 
         fn withdraw_from_prediction_account(
             ref self: ContractState,
             operator_nonce: u64,
+            signature: Signature,
             to_position_id: PositionId,
             client_id: felt252,
             quantized_amount: u64,
+            expiration: Timestamp,
+            salt: felt252,
         ) {
             self.pausable.assert_not_paused();
             self.operator_nonce.use_checked_nonce(:operator_nonce);
-
-            let amount = quantized_amount;
-            self.prediction_positions.withdraw_collateral(:client_id, :amount);
-
-            let position_diff = PositionDiff {
-                collateral_diff: quantized_amount.into(), asset_diff: Option::None,
-            };
-
-            self.positions.apply_diff(position_id: to_position_id, :position_diff);
+            self
+                .external_components
+                ._get_predictions_dispatcher()
+                .withdraw_from_prediction_account(
+                    :signature, :to_position_id, :client_id, :quantized_amount, :expiration, :salt,
+                );
         }
 
-        fn get_prediction_collateral(self: @ContractState, client_id: felt252) -> u64 {
-            self.prediction_positions.get_collateral(:client_id)
-        }
     }
 
     #[generate_trait]

--- a/workspace/apps/perpetuals/contracts/src/core/interface.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/interface.cairo
@@ -213,16 +213,21 @@ pub trait ICore<TContractState> {
     fn deposit_to_prediction_account(
         ref self: TContractState,
         operator_nonce: u64,
+        signature: Signature,
         from_position_id: PositionId,
         client_id: felt252,
         quantized_amount: u64,
+        expiration: Timestamp,
+        salt: felt252,
     );
     fn withdraw_from_prediction_account(
         ref self: TContractState,
         operator_nonce: u64,
+        signature: Signature,
         to_position_id: PositionId,
         client_id: felt252,
         quantized_amount: u64,
+        expiration: Timestamp,
+        salt: felt252,
     );
-    fn get_prediction_collateral(self: @TContractState, client_id: felt252) -> u64;
 }

--- a/workspace/apps/perpetuals/contracts/src/core/interface.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/interface.cairo
@@ -206,4 +206,23 @@ pub trait ICore<TContractState> {
     fn enable_escape_hatch(ref self: TContractState);
     fn get_max_interest_rate_per_sec(self: @TContractState) -> u32;
     fn set_max_interest_rate_per_sec(ref self: TContractState, max_interest_rate_per_sec: u32);
+
+    fn create_prediction_account(
+        ref self: TContractState, client_id: felt252, owning_key: felt252,
+    );
+    fn deposit_to_prediction_account(
+        ref self: TContractState,
+        operator_nonce: u64,
+        from_position_id: PositionId,
+        client_id: felt252,
+        quantized_amount: u64,
+    );
+    fn withdraw_from_prediction_account(
+        ref self: TContractState,
+        operator_nonce: u64,
+        to_position_id: PositionId,
+        client_id: felt252,
+        quantized_amount: u64,
+    );
+    fn get_prediction_collateral(self: @TContractState, client_id: felt252) -> u64;
 }

--- a/workspace/apps/perpetuals/contracts/src/lib.cairo
+++ b/workspace/apps/perpetuals/contracts/src/lib.cairo
@@ -1,4 +1,6 @@
 pub mod core;
 
+pub mod predictions;
+
 #[cfg(test)]
 mod tests;

--- a/workspace/apps/perpetuals/contracts/src/predictions.cairo
+++ b/workspace/apps/perpetuals/contracts/src/predictions.cairo
@@ -1,0 +1,5 @@
+pub mod prediction_positions;
+pub mod predictions;
+pub mod types;
+
+pub use prediction_positions::PredictionPositionsComponent;

--- a/workspace/apps/perpetuals/contracts/src/predictions/prediction_positions.cairo
+++ b/workspace/apps/perpetuals/contracts/src/predictions/prediction_positions.cairo
@@ -16,6 +16,17 @@ pub mod PredictionPositionsComponent {
     pub impl InternalImpl<
         TContractState, +HasComponent<TContractState>, +Drop<TContractState>,
     > of InternalTrait<TContractState> {
+        fn create_account(
+            ref self: ComponentState<TContractState>,
+            client_id: felt252,
+            owning_key: felt252,
+        ) {
+            let account = self.accounts.entry(client_id);
+            assert!(account.owning_key.read().is_zero(), "ACCOUNT_ALREADY_EXISTS");
+            assert!(owning_key.is_non_zero(), "INVALID_ZERO_OWNING_KEY");
+            account.owning_key.write(owning_key);
+        }
+
         fn deposit_collateral(
             ref self: ComponentState<TContractState>,
             client_id: felt252,

--- a/workspace/apps/perpetuals/contracts/src/predictions/prediction_positions.cairo
+++ b/workspace/apps/perpetuals/contracts/src/predictions/prediction_positions.cairo
@@ -1,3 +1,8 @@
+#[starknet::interface]
+pub trait IPredictionPositions<TContractState> {
+    fn get_prediction_collateral(self: @TContractState, client_id: felt252) -> u64;
+}
+
 #[starknet::component]
 pub mod PredictionPositionsComponent {
     use core::num::traits::Zero;
@@ -12,6 +17,17 @@ pub mod PredictionPositionsComponent {
     #[event]
     #[derive(Drop, PartialEq, starknet::Event)]
     pub enum Event {}
+
+    #[embeddable_as(PredictionPositionsImpl)]
+    impl PredictionPositionsExternal<
+        TContractState, +HasComponent<TContractState>, +Drop<TContractState>,
+    > of super::IPredictionPositions<ComponentState<TContractState>> {
+        fn get_prediction_collateral(
+            self: @ComponentState<TContractState>, client_id: felt252,
+        ) -> u64 {
+            self.accounts.entry(client_id).collateral.read()
+        }
+    }
 
     #[generate_trait]
     pub impl InternalImpl<
@@ -73,8 +89,9 @@ pub mod PredictionPositionsComponent {
             self: @ComponentState<TContractState>,
             client_id: felt252,
             market_id: felt252,
+            outcome_id: felt252,
         ) -> MarketPosition {
-            self.accounts.entry(client_id).tokens.entry(market_id).read()
+            self.accounts.entry(client_id).tokens.entry(market_id).entry(outcome_id).read()
         }
     }
 }

--- a/workspace/apps/perpetuals/contracts/src/predictions/prediction_positions.cairo
+++ b/workspace/apps/perpetuals/contracts/src/predictions/prediction_positions.cairo
@@ -50,6 +50,7 @@ pub mod PredictionPositionsComponent {
             amount: u64,
         ) {
             let account = self.accounts.entry(client_id);
+            assert!(account.owning_key.read().is_non_zero(), "ACCOUNT_DOES_NOT_EXIST");
             let current_collateral = account.collateral.read();
             account.collateral.write(current_collateral + amount);
         }
@@ -60,6 +61,7 @@ pub mod PredictionPositionsComponent {
             amount: u64,
         ) {
             let account = self.accounts.entry(client_id);
+            assert!(account.owning_key.read().is_non_zero(), "ACCOUNT_DOES_NOT_EXIST");
             let current_collateral = account.collateral.read();
             assert!(current_collateral >= amount, "INSUFFICIENT_PREDICTION_COLLATERAL");
             account.collateral.write(current_collateral - amount);

--- a/workspace/apps/perpetuals/contracts/src/predictions/prediction_positions.cairo
+++ b/workspace/apps/perpetuals/contracts/src/predictions/prediction_positions.cairo
@@ -1,0 +1,68 @@
+#[starknet::component]
+pub mod PredictionPositionsComponent {
+    use perpetuals::predictions::types::{Account, MarketPosition};
+    use starknet::storage::{Map, StoragePathEntry, StoragePointerReadAccess, StoragePointerWriteAccess};
+
+    #[storage]
+    pub struct Storage {
+        pub accounts: Map<felt252, Account>,
+    }
+
+    #[event]
+    #[derive(Drop, PartialEq, starknet::Event)]
+    pub enum Event {}
+
+    #[generate_trait]
+    pub impl InternalImpl<
+        TContractState, +HasComponent<TContractState>, +Drop<TContractState>,
+    > of InternalTrait<TContractState> {
+        fn deposit_collateral(
+            ref self: ComponentState<TContractState>,
+            client_id: felt252,
+            dp3_amount: u64,
+        ) {
+            let account = self.accounts.entry(client_id);
+            let current_collateral = account.collateral.read();
+            account.collateral.write(current_collateral + dp3_amount);
+        }
+
+        fn withdraw_collateral(
+            ref self: ComponentState<TContractState>,
+            client_id: felt252,
+            dp3_amount: u64,
+        ) {
+            let account = self.accounts.entry(client_id);
+            let current_collateral = account.collateral.read();
+            assert!(current_collateral >= dp3_amount, "INSUFFICIENT_PREDICTION_COLLATERAL");
+            account.collateral.write(current_collateral - dp3_amount);
+        }
+
+        fn get_collateral(
+            self: @ComponentState<TContractState>, client_id: felt252,
+        ) -> u64 {
+            self.accounts.entry(client_id).collateral.read()
+        }
+
+        fn get_owning_key(
+            self: @ComponentState<TContractState>, client_id: felt252,
+        ) -> felt252 {
+            self.accounts.entry(client_id).owning_key.read()
+        }
+
+        fn set_owning_key(
+            ref self: ComponentState<TContractState>,
+            client_id: felt252,
+            owning_key: felt252,
+        ) {
+            self.accounts.entry(client_id).owning_key.write(owning_key);
+        }
+
+        fn get_market_position(
+            self: @ComponentState<TContractState>,
+            client_id: felt252,
+            market_id: felt252,
+        ) -> MarketPosition {
+            self.accounts.entry(client_id).tokens.entry(market_id).read()
+        }
+    }
+}

--- a/workspace/apps/perpetuals/contracts/src/predictions/prediction_positions.cairo
+++ b/workspace/apps/perpetuals/contracts/src/predictions/prediction_positions.cairo
@@ -1,5 +1,6 @@
 #[starknet::component]
 pub mod PredictionPositionsComponent {
+    use core::num::traits::Zero;
     use perpetuals::predictions::types::{Account, MarketPosition};
     use starknet::storage::{Map, StoragePathEntry, StoragePointerReadAccess, StoragePointerWriteAccess};
 
@@ -30,22 +31,22 @@ pub mod PredictionPositionsComponent {
         fn deposit_collateral(
             ref self: ComponentState<TContractState>,
             client_id: felt252,
-            dp3_amount: u64,
+            amount: u64,
         ) {
             let account = self.accounts.entry(client_id);
             let current_collateral = account.collateral.read();
-            account.collateral.write(current_collateral + dp3_amount);
+            account.collateral.write(current_collateral + amount);
         }
 
         fn withdraw_collateral(
             ref self: ComponentState<TContractState>,
             client_id: felt252,
-            dp3_amount: u64,
+            amount: u64,
         ) {
             let account = self.accounts.entry(client_id);
             let current_collateral = account.collateral.read();
-            assert!(current_collateral >= dp3_amount, "INSUFFICIENT_PREDICTION_COLLATERAL");
-            account.collateral.write(current_collateral - dp3_amount);
+            assert!(current_collateral >= amount, "INSUFFICIENT_PREDICTION_COLLATERAL");
+            account.collateral.write(current_collateral - amount);
         }
 
         fn get_collateral(

--- a/workspace/apps/perpetuals/contracts/src/predictions/predictions.cairo
+++ b/workspace/apps/perpetuals/contracts/src/predictions/predictions.cairo
@@ -3,6 +3,7 @@ use starknet::ContractAddress;
 
 #[starknet::interface]
 pub trait IPredictions<TContractState> {
+    fn create_account(ref self: TContractState, client_id: felt252, owning_key: felt252);
     fn deposit_to_prediction_account(
         ref self: TContractState,
         from_position_id: PositionId,
@@ -109,6 +110,10 @@ pub mod Predictions {
 
     #[abi(embed_v0)]
     impl PredictionsImpl of IPredictions<ContractState> {
+        fn create_account(ref self: ContractState, client_id: felt252, owning_key: felt252) {
+            self.prediction_positions.create_account(:client_id, :owning_key);
+        }
+
         fn deposit_to_prediction_account(
             ref self: ContractState,
             from_position_id: PositionId,

--- a/workspace/apps/perpetuals/contracts/src/predictions/predictions.cairo
+++ b/workspace/apps/perpetuals/contracts/src/predictions/predictions.cairo
@@ -1,6 +1,4 @@
 use perpetuals::core::types::position::PositionId;
-use perpetuals::predictions::types::{PredictionDepositArgs, PredictionWithdrawArgs};
-use starknet::ContractAddress;
 use starkware_utils::signature::stark::Signature;
 use starkware_utils::time::time::Timestamp;
 
@@ -38,12 +36,11 @@ pub mod Predictions {
     use perpetuals::core::components::fulfillment::interface::IFulfillment;
     use perpetuals::core::components::positions::Positions as PositionsComponent;
     use perpetuals::core::components::positions::Positions::InternalTrait as PositionsInternal;
-    use perpetuals::core::types::position::{PositionDiff, PositionId};
+    use perpetuals::core::types::position::{PositionDiff, PositionId, PositionTrait};
     use perpetuals::predictions::PredictionPositionsComponent;
     use perpetuals::predictions::prediction_positions::PredictionPositionsComponent::InternalTrait as PredictionPositionsInternal;
     use perpetuals::predictions::predictions::IPredictions;
     use perpetuals::predictions::types::{PredictionDepositArgs, PredictionWithdrawArgs};
-    use starknet::ContractAddress;
     use starkware_utils::components::pausable::PausableComponent;
     use starkware_utils::components::request_approvals::RequestApprovalsComponent;
     use starkware_utils::components::roles::RolesComponent;
@@ -53,6 +50,7 @@ pub mod Predictions {
     use crate::core::components::external_components::interface::EXTERNAL_COMPONENT_PREDICTIONS;
     use crate::core::components::external_components::named_component::ITypedComponent;
     use crate::core::components::snip::SNIP12MetadataImpl;
+    use core::num::traits::Zero;
 
     impl SnipImpl = SNIP12MetadataImpl;
 
@@ -151,12 +149,15 @@ pub mod Predictions {
             salt: felt252,
         ) {
             let deposit_args = PredictionDepositArgs {
-                client_id, amount: quantized_amount, expiration, salt,
+                client_id, from_position_id, amount: quantized_amount, expiration, salt,
             };
-            let hash = self._validate_prediction_signature(:signature, :client_id, :expiration, message: deposit_args);
+            let public_key = self
+                .positions
+                .get_position_snapshot(position_id: from_position_id)
+                .get_owner_public_key();
+            let hash = self._validate_prediction_signature(:signature, :public_key, :expiration, message: deposit_args);
 
-            let amount_felt: felt252 = quantized_amount.into();
-            let amount_i64: i64 = amount_felt.try_into().unwrap();
+            let amount_i64: i64 = quantized_amount.try_into().unwrap();
             self
                 .fulfillment_tracking
                 .update_fulfillment(
@@ -184,8 +185,7 @@ pub mod Predictions {
 
             self.positions.apply_diff(position_id: from_position_id, :position_diff);
 
-            let amount = quantized_amount;
-            self.prediction_positions.deposit_collateral(:client_id, :amount);
+            self.prediction_positions.deposit_collateral(:client_id, amount: quantized_amount);
         }
 
         fn withdraw_from_prediction_account(
@@ -198,12 +198,13 @@ pub mod Predictions {
             salt: felt252,
         ) {
             let withdraw_args = PredictionWithdrawArgs {
-                client_id, amount: quantized_amount, expiration, salt,
+                client_id, to_position_id, amount: quantized_amount, expiration, salt,
             };
-            let hash = self._validate_prediction_signature(:signature, :client_id, :expiration, message: withdraw_args);
+            let public_key = self.prediction_positions.get_owning_key(:client_id);
+            assert!(public_key.is_non_zero(), "ACCOUNT_DOES_NOT_EXIST");
+            let hash = self._validate_prediction_signature(:signature, :public_key, :expiration, message: withdraw_args);
 
-            let amount_felt: felt252 = quantized_amount.into();
-            let amount_i64: i64 = amount_felt.try_into().unwrap();
+            let amount_i64: i64 = quantized_amount.try_into().unwrap();
             self
                 .fulfillment_tracking
                 .update_fulfillment(
@@ -213,9 +214,8 @@ pub mod Predictions {
                     actual_base_amount: amount_i64,
                 );
 
-            let amount = quantized_amount;
             // Debit the prediction account.
-            self.prediction_positions.withdraw_collateral(:client_id, :amount);
+            self.prediction_positions.withdraw_collateral(:client_id, amount: quantized_amount);
 
             let position_diff = PositionDiff {
                 collateral_diff: quantized_amount.into(), asset_diff: Option::None,
@@ -230,12 +230,11 @@ pub mod Predictions {
         fn _validate_prediction_signature<T, +Drop<T>, +Copy<T>, +OffchainMessageHash<T>>(
             self: @ContractState,
             signature: Signature,
-            client_id: felt252,
+            public_key: felt252,
             expiration: Timestamp,
             message: T,
         ) -> felt252 {
             assert!(Time::now() <= expiration, "SIGNATURE_EXPIRED");
-            let public_key = self.prediction_positions.get_owning_key(:client_id);
             let msg_hash = message.get_message_hash(:public_key);
             validate_stark_signature(:public_key, :msg_hash, :signature);
             msg_hash

--- a/workspace/apps/perpetuals/contracts/src/predictions/predictions.cairo
+++ b/workspace/apps/perpetuals/contracts/src/predictions/predictions.cairo
@@ -1,0 +1,165 @@
+use perpetuals::core::types::position::PositionId;
+use starknet::ContractAddress;
+
+#[starknet::interface]
+pub trait IPredictions<TContractState> {
+    fn deposit_to_prediction_account(
+        ref self: TContractState,
+        from_position_id: PositionId,
+        client_id: felt252,
+        quantized_amount: u64,
+        caller_address: ContractAddress,
+    );
+    fn withdraw_from_prediction_account(
+        ref self: TContractState,
+        to_position_id: PositionId,
+        client_id: felt252,
+        dp3_amount: u64,
+        caller_address: ContractAddress,
+    );
+}
+
+#[starknet::contract]
+pub mod Predictions {
+    use openzeppelin::access::accesscontrol::AccessControlComponent;
+    use openzeppelin::introspection::src5::SRC5Component;
+    use perpetuals::core::components::assets::AssetsComponent;
+    use perpetuals::core::components::assets::interface::IAssets;
+    use perpetuals::core::components::exchange_time::ExchangeTimeComponent;
+    use perpetuals::core::components::operator_nonce::OperatorNonceComponent;
+    use perpetuals::core::components::positions::Positions as PositionsComponent;
+    use perpetuals::core::components::positions::Positions::InternalTrait as PositionsInternal;
+    use perpetuals::core::types::position::{PositionDiff, PositionId};
+    use perpetuals::predictions::PredictionPositionsComponent;
+    use perpetuals::predictions::prediction_positions::PredictionPositionsComponent::InternalTrait as PredictionPositionsInternal;
+    use perpetuals::predictions::types::Dp3Trait;
+    use starknet::ContractAddress;
+    use starkware_utils::components::pausable::PausableComponent;
+    use starkware_utils::components::request_approvals::RequestApprovalsComponent;
+    use starkware_utils::components::roles::RolesComponent;
+
+    use super::IPredictions;
+
+    #[event]
+    #[derive(Drop, starknet::Event)]
+    pub enum Event {
+        #[flat]
+        PositionsEvent: PositionsComponent::Event,
+        #[flat]
+        PausableEvent: PausableComponent::Event,
+        #[flat]
+        OperatorNonceEvent: OperatorNonceComponent::Event,
+        #[flat]
+        AssetsEvent: AssetsComponent::Event,
+        #[flat]
+        RequestApprovalsEvent: RequestApprovalsComponent::Event,
+        #[flat]
+        SRC5Event: SRC5Component::Event,
+        #[flat]
+        AccessControlEvent: AccessControlComponent::Event,
+        #[flat]
+        RolesEvent: RolesComponent::Event,
+        #[flat]
+        ExchangeTimeEvent: ExchangeTimeComponent::Event,
+        #[flat]
+        PredictionPositionsEvent: PredictionPositionsComponent::Event,
+    }
+
+    #[storage]
+    pub struct Storage {
+        #[substorage(v0)]
+        pub positions: PositionsComponent::Storage,
+        #[substorage(v0)]
+        pausable: PausableComponent::Storage,
+        #[substorage(v0)]
+        operator_nonce: OperatorNonceComponent::Storage,
+        #[substorage(v0)]
+        #[allow(starknet::colliding_storage_paths)]
+        pub assets: AssetsComponent::Storage,
+        #[substorage(v0)]
+        pub request_approvals: RequestApprovalsComponent::Storage,
+        #[substorage(v0)]
+        src5: SRC5Component::Storage,
+        #[substorage(v0)]
+        accesscontrol: AccessControlComponent::Storage,
+        #[substorage(v0)]
+        pub roles: RolesComponent::Storage,
+        #[substorage(v0)]
+        exchange_time: ExchangeTimeComponent::Storage,
+        #[substorage(v0)]
+        pub prediction_positions: PredictionPositionsComponent::Storage,
+    }
+
+    component!(path: PositionsComponent, storage: positions, event: PositionsEvent);
+    component!(path: PausableComponent, storage: pausable, event: PausableEvent);
+    component!(path: OperatorNonceComponent, storage: operator_nonce, event: OperatorNonceEvent);
+    component!(path: AssetsComponent, storage: assets, event: AssetsEvent);
+    component!(
+        path: RequestApprovalsComponent, storage: request_approvals, event: RequestApprovalsEvent,
+    );
+    component!(path: SRC5Component, storage: src5, event: SRC5Event);
+    component!(path: AccessControlComponent, storage: accesscontrol, event: AccessControlEvent);
+    component!(path: RolesComponent, storage: roles, event: RolesEvent);
+    component!(path: ExchangeTimeComponent, storage: exchange_time, event: ExchangeTimeEvent);
+    component!(
+        path: PredictionPositionsComponent,
+        storage: prediction_positions,
+        event: PredictionPositionsEvent,
+    );
+
+    #[abi(embed_v0)]
+    impl PredictionsImpl of IPredictions<ContractState> {
+        fn deposit_to_prediction_account(
+            ref self: ContractState,
+            from_position_id: PositionId,
+            client_id: felt252,
+            quantized_amount: u64,
+            caller_address: ContractAddress,
+        ) {
+            let position = self.positions.get_position_mut(position_id: from_position_id);
+
+            // Pull collateral from the perpetuals position.
+            let position_diff = PositionDiff {
+                collateral_diff: -(quantized_amount.into()), asset_diff: Option::None,
+            };
+
+            self
+                .positions
+                .validate_healthy_or_healthier_position(
+                    position_id: from_position_id,
+                    position: position.into(),
+                    :position_diff,
+                    tvtr_before: Default::default(),
+                );
+
+            self.positions.apply_diff(position_id: from_position_id, :position_diff);
+
+            // Translate quantized amount to dp3 and credit the prediction account.
+            let collateral_quantum = self.assets.get_collateral_quantum();
+            let dp3_amount = Dp3Trait::quantized_to_dp3(:quantized_amount, :collateral_quantum);
+
+            self.prediction_positions.deposit_collateral(:client_id, :dp3_amount);
+        }
+
+        fn withdraw_from_prediction_account(
+            ref self: ContractState,
+            to_position_id: PositionId,
+            client_id: felt252,
+            dp3_amount: u64,
+            caller_address: ContractAddress,
+        ) {
+            // Debit the prediction account.
+            self.prediction_positions.withdraw_collateral(:client_id, :dp3_amount);
+
+            // Translate dp3 back to quantized and credit the perpetuals position.
+            let collateral_quantum = self.assets.get_collateral_quantum();
+            let quantized_amount = Dp3Trait::dp3_to_quantized(:dp3_amount, :collateral_quantum);
+
+            let position_diff = PositionDiff {
+                collateral_diff: quantized_amount.into(), asset_diff: Option::None,
+            };
+
+            self.positions.apply_diff(position_id: to_position_id, :position_diff);
+        }
+    }
+}

--- a/workspace/apps/perpetuals/contracts/src/predictions/predictions.cairo
+++ b/workspace/apps/perpetuals/contracts/src/predictions/predictions.cairo
@@ -15,7 +15,7 @@ pub trait IPredictions<TContractState> {
         ref self: TContractState,
         to_position_id: PositionId,
         client_id: felt252,
-        dp3_amount: u64,
+        quantized_amount: u64,
         caller_address: ContractAddress,
     );
 }
@@ -25,7 +25,6 @@ pub mod Predictions {
     use openzeppelin::access::accesscontrol::AccessControlComponent;
     use openzeppelin::introspection::src5::SRC5Component;
     use perpetuals::core::components::assets::AssetsComponent;
-    use perpetuals::core::components::assets::interface::IAssets;
     use perpetuals::core::components::exchange_time::ExchangeTimeComponent;
     use perpetuals::core::components::operator_nonce::OperatorNonceComponent;
     use perpetuals::core::components::positions::Positions as PositionsComponent;
@@ -33,13 +32,11 @@ pub mod Predictions {
     use perpetuals::core::types::position::{PositionDiff, PositionId};
     use perpetuals::predictions::PredictionPositionsComponent;
     use perpetuals::predictions::prediction_positions::PredictionPositionsComponent::InternalTrait as PredictionPositionsInternal;
-    use perpetuals::predictions::types::Dp3Trait;
+    use perpetuals::predictions::predictions::IPredictions;
     use starknet::ContractAddress;
     use starkware_utils::components::pausable::PausableComponent;
     use starkware_utils::components::request_approvals::RequestApprovalsComponent;
     use starkware_utils::components::roles::RolesComponent;
-
-    use super::IPredictions;
 
     #[event]
     #[derive(Drop, starknet::Event)]
@@ -139,26 +136,20 @@ pub mod Predictions {
 
             self.positions.apply_diff(position_id: from_position_id, :position_diff);
 
-            // Translate quantized amount to dp3 and credit the prediction account.
-            let collateral_quantum = self.assets.get_collateral_quantum();
-            let dp3_amount = Dp3Trait::quantized_to_dp3(:quantized_amount, :collateral_quantum);
-
-            self.prediction_positions.deposit_collateral(:client_id, :dp3_amount);
+            let amount = quantized_amount;
+            self.prediction_positions.deposit_collateral(:client_id, :amount);
         }
 
         fn withdraw_from_prediction_account(
             ref self: ContractState,
             to_position_id: PositionId,
             client_id: felt252,
-            dp3_amount: u64,
+            quantized_amount: u64,
             caller_address: ContractAddress,
         ) {
+            let amount = quantized_amount;
             // Debit the prediction account.
-            self.prediction_positions.withdraw_collateral(:client_id, :dp3_amount);
-
-            // Translate dp3 back to quantized and credit the perpetuals position.
-            let collateral_quantum = self.assets.get_collateral_quantum();
-            let quantized_amount = Dp3Trait::dp3_to_quantized(:dp3_amount, :collateral_quantum);
+            self.prediction_positions.withdraw_collateral(:client_id, :amount);
 
             let position_diff = PositionDiff {
                 collateral_diff: quantized_amount.into(), asset_diff: Option::None,

--- a/workspace/apps/perpetuals/contracts/src/predictions/predictions.cairo
+++ b/workspace/apps/perpetuals/contracts/src/predictions/predictions.cairo
@@ -1,22 +1,29 @@
 use perpetuals::core::types::position::PositionId;
+use perpetuals::predictions::types::{PredictionDepositArgs, PredictionWithdrawArgs};
 use starknet::ContractAddress;
+use starkware_utils::signature::stark::Signature;
+use starkware_utils::time::time::Timestamp;
 
 #[starknet::interface]
 pub trait IPredictions<TContractState> {
     fn create_account(ref self: TContractState, client_id: felt252, owning_key: felt252);
     fn deposit_to_prediction_account(
         ref self: TContractState,
+        signature: Signature,
         from_position_id: PositionId,
         client_id: felt252,
         quantized_amount: u64,
-        caller_address: ContractAddress,
+        expiration: Timestamp,
+        salt: felt252,
     );
     fn withdraw_from_prediction_account(
         ref self: TContractState,
+        signature: Signature,
         to_position_id: PositionId,
         client_id: felt252,
         quantized_amount: u64,
-        caller_address: ContractAddress,
+        expiration: Timestamp,
+        salt: felt252,
     );
 }
 
@@ -27,16 +34,27 @@ pub mod Predictions {
     use perpetuals::core::components::assets::AssetsComponent;
     use perpetuals::core::components::exchange_time::ExchangeTimeComponent;
     use perpetuals::core::components::operator_nonce::OperatorNonceComponent;
+    use perpetuals::core::components::fulfillment::fulfillment::Fulfillement;
+    use perpetuals::core::components::fulfillment::interface::IFulfillment;
     use perpetuals::core::components::positions::Positions as PositionsComponent;
     use perpetuals::core::components::positions::Positions::InternalTrait as PositionsInternal;
     use perpetuals::core::types::position::{PositionDiff, PositionId};
     use perpetuals::predictions::PredictionPositionsComponent;
     use perpetuals::predictions::prediction_positions::PredictionPositionsComponent::InternalTrait as PredictionPositionsInternal;
     use perpetuals::predictions::predictions::IPredictions;
+    use perpetuals::predictions::types::{PredictionDepositArgs, PredictionWithdrawArgs};
     use starknet::ContractAddress;
     use starkware_utils::components::pausable::PausableComponent;
     use starkware_utils::components::request_approvals::RequestApprovalsComponent;
     use starkware_utils::components::roles::RolesComponent;
+    use starkware_utils::signature::stark::{Signature, validate_stark_signature};
+    use starkware_utils::hash::message_hash::OffchainMessageHash;
+    use starkware_utils::time::time::{Time, Timestamp};
+    use crate::core::components::external_components::interface::EXTERNAL_COMPONENT_PREDICTIONS;
+    use crate::core::components::external_components::named_component::ITypedComponent;
+    use crate::core::components::snip::SNIP12MetadataImpl;
+
+    impl SnipImpl = SNIP12MetadataImpl;
 
     #[event]
     #[derive(Drop, starknet::Event)]
@@ -61,6 +79,8 @@ pub mod Predictions {
         ExchangeTimeEvent: ExchangeTimeComponent::Event,
         #[flat]
         PredictionPositionsEvent: PredictionPositionsComponent::Event,
+        #[flat]
+        FulfillmentEvent: Fulfillement::Event,
     }
 
     #[storage]
@@ -86,6 +106,8 @@ pub mod Predictions {
         exchange_time: ExchangeTimeComponent::Storage,
         #[substorage(v0)]
         pub prediction_positions: PredictionPositionsComponent::Storage,
+        #[substorage(v0)]
+        pub fulfillment_tracking: Fulfillement::Storage,
     }
 
     component!(path: PositionsComponent, storage: positions, event: PositionsEvent);
@@ -104,6 +126,14 @@ pub mod Predictions {
         storage: prediction_positions,
         event: PredictionPositionsEvent,
     );
+    component!(path: Fulfillement, storage: fulfillment_tracking, event: FulfillmentEvent);
+
+    #[abi(embed_v0)]
+    impl TypedComponent of ITypedComponent<ContractState> {
+        fn component_type(ref self: ContractState) -> felt252 {
+            EXTERNAL_COMPONENT_PREDICTIONS
+        }
+    }
 
     #[abi(embed_v0)]
     impl PredictionsImpl of IPredictions<ContractState> {
@@ -113,11 +143,29 @@ pub mod Predictions {
 
         fn deposit_to_prediction_account(
             ref self: ContractState,
+            signature: Signature,
             from_position_id: PositionId,
             client_id: felt252,
             quantized_amount: u64,
-            caller_address: ContractAddress,
+            expiration: Timestamp,
+            salt: felt252,
         ) {
+            let deposit_args = PredictionDepositArgs {
+                client_id, amount: quantized_amount, expiration, salt,
+            };
+            let hash = self._validate_prediction_signature(:signature, :client_id, :expiration, message: deposit_args);
+
+            let amount_felt: felt252 = quantized_amount.into();
+            let amount_i64: i64 = amount_felt.try_into().unwrap();
+            self
+                .fulfillment_tracking
+                .update_fulfillment(
+                    position_id: from_position_id,
+                    :hash,
+                    order_base_amount: amount_i64,
+                    actual_base_amount: amount_i64,
+                );
+
             let position = self.positions.get_position_mut(position_id: from_position_id);
 
             // Pull collateral from the perpetuals position.
@@ -142,11 +190,29 @@ pub mod Predictions {
 
         fn withdraw_from_prediction_account(
             ref self: ContractState,
+            signature: Signature,
             to_position_id: PositionId,
             client_id: felt252,
             quantized_amount: u64,
-            caller_address: ContractAddress,
+            expiration: Timestamp,
+            salt: felt252,
         ) {
+            let withdraw_args = PredictionWithdrawArgs {
+                client_id, amount: quantized_amount, expiration, salt,
+            };
+            let hash = self._validate_prediction_signature(:signature, :client_id, :expiration, message: withdraw_args);
+
+            let amount_felt: felt252 = quantized_amount.into();
+            let amount_i64: i64 = amount_felt.try_into().unwrap();
+            self
+                .fulfillment_tracking
+                .update_fulfillment(
+                    position_id: to_position_id,
+                    :hash,
+                    order_base_amount: amount_i64,
+                    actual_base_amount: amount_i64,
+                );
+
             let amount = quantized_amount;
             // Debit the prediction account.
             self.prediction_positions.withdraw_collateral(:client_id, :amount);
@@ -156,6 +222,23 @@ pub mod Predictions {
             };
 
             self.positions.apply_diff(position_id: to_position_id, :position_diff);
+        }
+    }
+
+    #[generate_trait]
+    impl PrivateImpl of PrivateTrait {
+        fn _validate_prediction_signature<T, +Drop<T>, +Copy<T>, +OffchainMessageHash<T>>(
+            self: @ContractState,
+            signature: Signature,
+            client_id: felt252,
+            expiration: Timestamp,
+            message: T,
+        ) -> felt252 {
+            assert!(Time::now() <= expiration, "SIGNATURE_EXPIRED");
+            let public_key = self.prediction_positions.get_owning_key(:client_id);
+            let msg_hash = message.get_message_hash(:public_key);
+            validate_stark_signature(:public_key, :msg_hash, :signature);
+            msg_hash
         }
     }
 }

--- a/workspace/apps/perpetuals/contracts/src/predictions/types.cairo
+++ b/workspace/apps/perpetuals/contracts/src/predictions/types.cairo
@@ -1,6 +1,7 @@
 use core::hash::{HashStateExTrait, HashStateTrait};
 use core::poseidon::PoseidonTrait;
 use openzeppelin::utils::snip12::StructHash;
+use perpetuals::core::types::position::PositionId;
 use starknet::storage::Map;
 use starkware_utils::signature::stark::HashType;
 use starkware_utils::time::time::Timestamp;
@@ -20,6 +21,7 @@ pub struct Account {
 #[derive(Copy, Drop, Hash, Serde)]
 pub struct PredictionDepositArgs {
     pub client_id: felt252,
+    pub from_position_id: PositionId,
     pub amount: u64,
     pub expiration: Timestamp,
     pub salt: felt252,
@@ -28,6 +30,7 @@ pub struct PredictionDepositArgs {
 /// selector!(
 ///   "\"PredictionDepositArgs\"(
 ///    \"client_id\":\"felt\",
+///    \"from_position_id\":\"felt\",
 ///    \"amount\":\"u64\",
 ///    \"expiration\":\"Timestamp\",
 ///    \"salt\":\"felt\"
@@ -38,7 +41,7 @@ pub struct PredictionDepositArgs {
 /// );
 const DEPOSIT_ARGS_TYPE_HASH: HashType =
     selector!(
-        "\"PredictionDepositArgs\"(\"client_id\":\"felt\",\"amount\":\"u64\",\"expiration\":\"Timestamp\",\"salt\":\"felt\")\"Timestamp\"(\"seconds\":\"u64\")",
+        "\"PredictionDepositArgs\"(\"client_id\":\"felt\",\"from_position_id\":\"felt\",\"amount\":\"u64\",\"expiration\":\"Timestamp\",\"salt\":\"felt\")\"Timestamp\"(\"seconds\":\"u64\")",
     );
 
 impl PredictionDepositArgsStructHashImpl of StructHash<PredictionDepositArgs> {
@@ -51,6 +54,7 @@ impl PredictionDepositArgsStructHashImpl of StructHash<PredictionDepositArgs> {
 #[derive(Copy, Drop, Hash, Serde)]
 pub struct PredictionWithdrawArgs {
     pub client_id: felt252,
+    pub to_position_id: PositionId,
     pub amount: u64,
     pub expiration: Timestamp,
     pub salt: felt252,
@@ -59,6 +63,7 @@ pub struct PredictionWithdrawArgs {
 /// selector!(
 ///   "\"PredictionWithdrawArgs\"(
 ///    \"client_id\":\"felt\",
+///    \"to_position_id\":\"felt\",
 ///    \"amount\":\"u64\",
 ///    \"expiration\":\"Timestamp\",
 ///    \"salt\":\"felt\"
@@ -69,7 +74,7 @@ pub struct PredictionWithdrawArgs {
 /// );
 const WITHDRAW_ARGS_TYPE_HASH: HashType =
     selector!(
-        "\"PredictionWithdrawArgs\"(\"client_id\":\"felt\",\"amount\":\"u64\",\"expiration\":\"Timestamp\",\"salt\":\"felt\")\"Timestamp\"(\"seconds\":\"u64\")",
+        "\"PredictionWithdrawArgs\"(\"client_id\":\"felt\",\"to_position_id\":\"felt\",\"amount\":\"u64\",\"expiration\":\"Timestamp\",\"salt\":\"felt\")\"Timestamp\"(\"seconds\":\"u64\")",
     );
 
 impl PredictionWithdrawArgsStructHashImpl of StructHash<PredictionWithdrawArgs> {

--- a/workspace/apps/perpetuals/contracts/src/predictions/types.cairo
+++ b/workspace/apps/perpetuals/contracts/src/predictions/types.cairo
@@ -1,8 +1,5 @@
 use starknet::storage::Map;
 
-// Converts base token units (10^-6 for USDC) to dp3 (10^-3).
-pub const BASE_TO_DP3_DIVISOR: u64 = 1000;
-
 #[derive(Copy, Drop, Serde, starknet::Store)]
 pub struct MarketPosition {
     pub amount: u64,
@@ -13,18 +10,4 @@ pub struct Account {
     pub owning_key: felt252,
     pub collateral: u64,
     pub tokens: Map<felt252, MarketPosition>,
-}
-
-#[generate_trait]
-pub impl Dp3Impl of Dp3Trait {
-    /// Converts a quantized amount to dp3 given the collateral quantum.
-    /// quantized * quantum gives base token units, then / BASE_TO_DP3_DIVISOR gives dp3.
-    fn quantized_to_dp3(quantized_amount: u64, collateral_quantum: u64) -> u64 {
-        (quantized_amount * collateral_quantum) / BASE_TO_DP3_DIVISOR
-    }
-
-    /// Converts a dp3 amount back to quantized given the collateral quantum.
-    fn dp3_to_quantized(dp3_amount: u64, collateral_quantum: u64) -> u64 {
-        (dp3_amount * BASE_TO_DP3_DIVISOR) / collateral_quantum
-    }
 }

--- a/workspace/apps/perpetuals/contracts/src/predictions/types.cairo
+++ b/workspace/apps/perpetuals/contracts/src/predictions/types.cairo
@@ -1,0 +1,30 @@
+use starknet::storage::Map;
+
+// Converts base token units (10^-6 for USDC) to dp3 (10^-3).
+pub const BASE_TO_DP3_DIVISOR: u64 = 1000;
+
+#[derive(Copy, Drop, Serde, starknet::Store)]
+pub struct MarketPosition {
+    pub amount: u64,
+}
+
+#[starknet::storage_node]
+pub struct Account {
+    pub owning_key: felt252,
+    pub collateral: u64,
+    pub tokens: Map<felt252, MarketPosition>,
+}
+
+#[generate_trait]
+pub impl Dp3Impl of Dp3Trait {
+    /// Converts a quantized amount to dp3 given the collateral quantum.
+    /// quantized * quantum gives base token units, then / BASE_TO_DP3_DIVISOR gives dp3.
+    fn quantized_to_dp3(quantized_amount: u64, collateral_quantum: u64) -> u64 {
+        (quantized_amount * collateral_quantum) / BASE_TO_DP3_DIVISOR
+    }
+
+    /// Converts a dp3 amount back to quantized given the collateral quantum.
+    fn dp3_to_quantized(dp3_amount: u64, collateral_quantum: u64) -> u64 {
+        (dp3_amount * BASE_TO_DP3_DIVISOR) / collateral_quantum
+    }
+}

--- a/workspace/apps/perpetuals/contracts/src/predictions/types.cairo
+++ b/workspace/apps/perpetuals/contracts/src/predictions/types.cairo
@@ -1,4 +1,9 @@
+use core::hash::{HashStateExTrait, HashStateTrait};
+use core::poseidon::PoseidonTrait;
+use openzeppelin::utils::snip12::StructHash;
 use starknet::storage::Map;
+use starkware_utils::signature::stark::HashType;
+use starkware_utils::time::time::Timestamp;
 
 #[derive(Copy, Drop, Serde, starknet::Store)]
 pub struct MarketPosition {
@@ -9,5 +14,67 @@ pub struct MarketPosition {
 pub struct Account {
     pub owning_key: felt252,
     pub collateral: u64,
-    pub tokens: Map<felt252, MarketPosition>,
+    pub tokens: Map<felt252, Map<felt252, MarketPosition>>,
+}
+
+#[derive(Copy, Drop, Hash, Serde)]
+pub struct PredictionDepositArgs {
+    pub client_id: felt252,
+    pub amount: u64,
+    pub expiration: Timestamp,
+    pub salt: felt252,
+}
+
+/// selector!(
+///   "\"PredictionDepositArgs\"(
+///    \"client_id\":\"felt\",
+///    \"amount\":\"u64\",
+///    \"expiration\":\"Timestamp\",
+///    \"salt\":\"felt\"
+///    )
+///    \"Timestamp\"(
+///    \"seconds\":\"u64\"
+///    )
+/// );
+const DEPOSIT_ARGS_TYPE_HASH: HashType =
+    selector!(
+        "\"PredictionDepositArgs\"(\"client_id\":\"felt\",\"amount\":\"u64\",\"expiration\":\"Timestamp\",\"salt\":\"felt\")\"Timestamp\"(\"seconds\":\"u64\")",
+    );
+
+impl PredictionDepositArgsStructHashImpl of StructHash<PredictionDepositArgs> {
+    fn hash_struct(self: @PredictionDepositArgs) -> HashType {
+        let hash_state = PoseidonTrait::new();
+        hash_state.update_with(DEPOSIT_ARGS_TYPE_HASH).update_with(*self).finalize()
+    }
+}
+
+#[derive(Copy, Drop, Hash, Serde)]
+pub struct PredictionWithdrawArgs {
+    pub client_id: felt252,
+    pub amount: u64,
+    pub expiration: Timestamp,
+    pub salt: felt252,
+}
+
+/// selector!(
+///   "\"PredictionWithdrawArgs\"(
+///    \"client_id\":\"felt\",
+///    \"amount\":\"u64\",
+///    \"expiration\":\"Timestamp\",
+///    \"salt\":\"felt\"
+///    )
+///    \"Timestamp\"(
+///    \"seconds\":\"u64\"
+///    )
+/// );
+const WITHDRAW_ARGS_TYPE_HASH: HashType =
+    selector!(
+        "\"PredictionWithdrawArgs\"(\"client_id\":\"felt\",\"amount\":\"u64\",\"expiration\":\"Timestamp\",\"salt\":\"felt\")\"Timestamp\"(\"seconds\":\"u64\")",
+    );
+
+impl PredictionWithdrawArgsStructHashImpl of StructHash<PredictionWithdrawArgs> {
+    fn hash_struct(self: @PredictionWithdrawArgs) -> HashType {
+        let hash_state = PoseidonTrait::new();
+        hash_state.update_with(WITHDRAW_ARGS_TYPE_HASH).update_with(*self).finalize()
+    }
 }

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests.cairo
@@ -6,6 +6,7 @@ mod infra;
 mod perps_tests_facade;
 mod procotol_vault_deposit_tests;
 mod procotol_vault_redeem_tests;
+mod prediction_tests;
 mod unit_flow_tests;
 mod vault_share_deposit_flow_tests;
 

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/perps_tests_facade.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/perps_tests_facade.cairo
@@ -2881,6 +2881,42 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
         IVaultsDispatcher { contract_address: self.perpetuals_contract }
             .update_vault_protection_limit(:vault_position, :percentage);
     }
+
+    fn create_prediction_account(
+        ref self: PerpsTestsFacade, client_id: felt252, owning_key: felt252,
+    ) {
+        self.operator.set_as_caller(self.perpetuals_contract);
+        ICoreDispatcher { contract_address: self.perpetuals_contract }
+            .create_prediction_account(:client_id, :owning_key);
+    }
+
+    fn deposit_to_prediction_account(
+        ref self: PerpsTestsFacade,
+        from_position_id: PositionId,
+        client_id: felt252,
+        quantized_amount: u64,
+    ) {
+        let operator_nonce = self.get_nonce();
+        self.operator.set_as_caller(self.perpetuals_contract);
+        ICoreDispatcher { contract_address: self.perpetuals_contract }
+            .deposit_to_prediction_account(
+                :operator_nonce, :from_position_id, :client_id, :quantized_amount,
+            );
+    }
+
+    fn withdraw_from_prediction_account(
+        ref self: PerpsTestsFacade,
+        to_position_id: PositionId,
+        client_id: felt252,
+        quantized_amount: u64,
+    ) {
+        let operator_nonce = self.get_nonce();
+        self.operator.set_as_caller(self.perpetuals_contract);
+        ICoreDispatcher { contract_address: self.perpetuals_contract }
+            .withdraw_from_prediction_account(
+                :operator_nonce, :to_position_id, :client_id, :quantized_amount,
+            );
+    }
 }
 
 
@@ -2945,6 +2981,14 @@ pub impl PerpsTestsFacadeValidationsImpl of PerpsTestsFacadeValidationsTrait {
         let dispatcher = IPositionsDispatcher { contract_address: *self.perpetuals_contract };
         let PositionTVTR { total_risk, .. } = dispatcher.get_position_tv_tr(position_id);
         assert_eq!(total_risk, expected_total_risk);
+    }
+
+    fn validate_prediction_collateral(
+        self: @PerpsTestsFacade, client_id: felt252, expected_collateral: u64,
+    ) {
+        let collateral = ICoreDispatcher { contract_address: *self.perpetuals_contract }
+            .get_prediction_collateral(:client_id);
+        assert_eq!(collateral, expected_collateral);
     }
 }
 

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/perps_tests_facade.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/perps_tests_facade.cairo
@@ -6,7 +6,8 @@ use core::num::traits::{WideMul, Zero};
 use external_components::interface::{
     EXTERNAL_COMPONENT_ASSETS, EXTERNAL_COMPONENT_DELEVERAGES, EXTERNAL_COMPONENT_DEPOSITS,
     EXTERNAL_COMPONENT_FORCED_REQUESTS, EXTERNAL_COMPONENT_LIQUIDATIONS,
-    EXTERNAL_COMPONENT_TRANSFERS, EXTERNAL_COMPONENT_VAULT, EXTERNAL_COMPONENT_WITHDRAWALS,
+    EXTERNAL_COMPONENT_PREDICTIONS, EXTERNAL_COMPONENT_TRANSFERS, EXTERNAL_COMPONENT_VAULT,
+    EXTERNAL_COMPONENT_WITHDRAWALS,
 };
 use openzeppelin::interfaces::erc20::IERC20Dispatcher;
 use openzeppelin::interfaces::erc4626::{IERC4626Dispatcher, IERC4626DispatcherTrait};
@@ -30,6 +31,10 @@ use perpetuals::core::components::positions::interface::{
 };
 use perpetuals::core::components::snip::SNIP12MetadataImpl;
 use perpetuals::core::components::vaults::vaults::{IVaultsDispatcher, IVaultsDispatcherTrait};
+use perpetuals::predictions::prediction_positions::{
+    IPredictionPositionsDispatcher, IPredictionPositionsDispatcherTrait,
+};
+use perpetuals::predictions::types::{PredictionDepositArgs, PredictionWithdrawArgs};
 use perpetuals::core::interface::{ICoreDispatcher, ICoreDispatcherTrait, Settlement};
 use perpetuals::core::types::asset::synthetic::{AssetBalanceInfo, AssetType};
 use perpetuals::core::types::asset::{AssetId, AssetIdTrait, AssetStatus};
@@ -578,6 +583,10 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
             .unwrap()
             .contract_class();
 
+        let predictions_external_component = snforge_std::declare("Predictions")
+            .unwrap()
+            .contract_class();
+
         let collateral_quantum = COLLATERAL_QUANTUM;
         let perpetuals_config: PerpetualsConfig = PerpetualsConfigTrait::new(
             collateral_token_address: token_state.address, :collateral_quantum,
@@ -656,6 +665,12 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
             );
 
         external_components_dispatcher
+            .register_external_component(
+                component_type: EXTERNAL_COMPONENT_PREDICTIONS,
+                component_address: *predictions_external_component.class_hash,
+            );
+
+        external_components_dispatcher
             .activate_external_component(
                 component_type: EXTERNAL_COMPONENT_DELEVERAGES,
                 component_address: *deleverage_external_component.class_hash,
@@ -697,6 +712,12 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
             .activate_external_component(
                 component_type: EXTERNAL_COMPONENT_FORCED_REQUESTS,
                 component_address: *forced_requests_external_component.class_hash,
+            );
+
+        external_components_dispatcher
+            .activate_external_component(
+                component_type: EXTERNAL_COMPONENT_PREDICTIONS,
+                component_address: *predictions_external_component.class_hash,
             );
 
         stop_cheat_caller_address(contract_address: perpetuals_contract);
@@ -2895,12 +2916,28 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
         from_position_id: PositionId,
         client_id: felt252,
         quantized_amount: u64,
+        owning_key_pair: StarkKeyPair,
     ) {
         let operator_nonce = self.get_nonce();
+        let expiration = Time::now();
+        let salt = self.generate_salt();
+        let deposit_args = PredictionDepositArgs {
+            client_id, amount: quantized_amount, expiration, salt,
+        };
+        let msg_hash = deposit_args.get_message_hash(owning_key_pair.public_key);
+        let (r, s) = owning_key_pair.sign(msg_hash).unwrap();
+        let signature = array![r, s].span();
+
         self.operator.set_as_caller(self.perpetuals_contract);
         ICoreDispatcher { contract_address: self.perpetuals_contract }
             .deposit_to_prediction_account(
-                :operator_nonce, :from_position_id, :client_id, :quantized_amount,
+                :operator_nonce,
+                :signature,
+                :from_position_id,
+                :client_id,
+                :quantized_amount,
+                :expiration,
+                :salt,
             );
     }
 
@@ -2909,12 +2946,28 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
         to_position_id: PositionId,
         client_id: felt252,
         quantized_amount: u64,
+        owning_key_pair: StarkKeyPair,
     ) {
         let operator_nonce = self.get_nonce();
+        let expiration = Time::now();
+        let salt = self.generate_salt();
+        let withdraw_args = PredictionWithdrawArgs {
+            client_id, amount: quantized_amount, expiration, salt,
+        };
+        let msg_hash = withdraw_args.get_message_hash(owning_key_pair.public_key);
+        let (r, s) = owning_key_pair.sign(msg_hash).unwrap();
+        let signature = array![r, s].span();
+
         self.operator.set_as_caller(self.perpetuals_contract);
         ICoreDispatcher { contract_address: self.perpetuals_contract }
             .withdraw_from_prediction_account(
-                :operator_nonce, :to_position_id, :client_id, :quantized_amount,
+                :operator_nonce,
+                :signature,
+                :to_position_id,
+                :client_id,
+                :quantized_amount,
+                :expiration,
+                :salt,
             );
     }
 }
@@ -2986,7 +3039,9 @@ pub impl PerpsTestsFacadeValidationsImpl of PerpsTestsFacadeValidationsTrait {
     fn validate_prediction_collateral(
         self: @PerpsTestsFacade, client_id: felt252, expected_collateral: u64,
     ) {
-        let collateral = ICoreDispatcher { contract_address: *self.perpetuals_contract }
+        let collateral = IPredictionPositionsDispatcher {
+            contract_address: *self.perpetuals_contract,
+        }
             .get_prediction_collateral(:client_id);
         assert_eq!(collateral, expected_collateral);
     }

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/perps_tests_facade.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/perps_tests_facade.cairo
@@ -2916,16 +2916,16 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
         from_position_id: PositionId,
         client_id: felt252,
         quantized_amount: u64,
-        owning_key_pair: StarkKeyPair,
+        signing_key_pair: StarkKeyPair,
     ) {
         let operator_nonce = self.get_nonce();
         let expiration = Time::now();
         let salt = self.generate_salt();
         let deposit_args = PredictionDepositArgs {
-            client_id, amount: quantized_amount, expiration, salt,
+            client_id, from_position_id, amount: quantized_amount, expiration, salt,
         };
-        let msg_hash = deposit_args.get_message_hash(owning_key_pair.public_key);
-        let (r, s) = owning_key_pair.sign(msg_hash).unwrap();
+        let msg_hash = deposit_args.get_message_hash(signing_key_pair.public_key);
+        let (r, s) = signing_key_pair.sign(msg_hash).unwrap();
         let signature = array![r, s].span();
 
         self.operator.set_as_caller(self.perpetuals_contract);
@@ -2946,16 +2946,16 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
         to_position_id: PositionId,
         client_id: felt252,
         quantized_amount: u64,
-        owning_key_pair: StarkKeyPair,
+        signing_key_pair: StarkKeyPair,
     ) {
         let operator_nonce = self.get_nonce();
         let expiration = Time::now();
         let salt = self.generate_salt();
         let withdraw_args = PredictionWithdrawArgs {
-            client_id, amount: quantized_amount, expiration, salt,
+            client_id, to_position_id, amount: quantized_amount, expiration, salt,
         };
-        let msg_hash = withdraw_args.get_message_hash(owning_key_pair.public_key);
-        let (r, s) = owning_key_pair.sign(msg_hash).unwrap();
+        let msg_hash = withdraw_args.get_message_hash(signing_key_pair.public_key);
+        let (r, s) = signing_key_pair.sign(msg_hash).unwrap();
         let signature = array![r, s].span();
 
         self.operator.set_as_caller(self.perpetuals_contract);

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/prediction_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/prediction_tests.cairo
@@ -1,0 +1,152 @@
+use perpetuals::tests::flow_tests::infra::*;
+use perpetuals::tests::flow_tests::perps_tests_facade::*;
+
+#[test]
+fn test_prediction_deposit_and_withdraw() {
+    // Setup.
+    let mut state: FlowTestBase = FlowTestBaseTrait::new();
+    let user = state.new_user_with_position();
+
+    // Deposit collateral to perps position.
+    let deposit_info = state
+        .facade
+        .deposit(
+            depositor: user.account, position_id: user.position_id, quantized_amount: 100_000,
+        );
+    state.facade.process_deposit(deposit_info: deposit_info);
+
+    // Create prediction account.
+    let client_id: felt252 = 1;
+    let owning_key: felt252 = 42;
+    state.facade.create_prediction_account(:client_id, :owning_key);
+    state.facade.validate_prediction_collateral(:client_id, expected_collateral: 0);
+
+    // Deposit from perps position to prediction account.
+    state
+        .facade
+        .deposit_to_prediction_account(
+            from_position_id: user.position_id, :client_id, quantized_amount: 50_000,
+        );
+
+    // Validate balances after deposit.
+    state
+        .facade
+        .validate_collateral_balance(
+            position_id: user.position_id, expected_balance: 50_000_i64.into(),
+        );
+    state.facade.validate_prediction_collateral(:client_id, expected_collateral: 50_000);
+
+    // Withdraw from prediction account back to perps position.
+    state
+        .facade
+        .withdraw_from_prediction_account(
+            to_position_id: user.position_id, :client_id, quantized_amount: 30_000,
+        );
+
+    // Validate balances after withdraw.
+    state
+        .facade
+        .validate_collateral_balance(
+            position_id: user.position_id, expected_balance: 80_000_i64.into(),
+        );
+    state.facade.validate_prediction_collateral(:client_id, expected_collateral: 20_000);
+}
+
+#[test]
+fn test_prediction_deposit_full_and_withdraw_full() {
+    // Setup.
+    let mut state: FlowTestBase = FlowTestBaseTrait::new();
+    let user = state.new_user_with_position();
+
+    let amount: u64 = 100_000;
+    let deposit_info = state
+        .facade
+        .deposit(
+            depositor: user.account, position_id: user.position_id, quantized_amount: amount,
+        );
+    state.facade.process_deposit(deposit_info: deposit_info);
+
+    // Create prediction account and deposit full amount.
+    let client_id: felt252 = 1;
+    let owning_key: felt252 = 42;
+    state.facade.create_prediction_account(:client_id, :owning_key);
+    state
+        .facade
+        .deposit_to_prediction_account(
+            from_position_id: user.position_id, :client_id, quantized_amount: amount,
+        );
+
+    state
+        .facade
+        .validate_collateral_balance(position_id: user.position_id, expected_balance: 0_i64.into());
+    state.facade.validate_prediction_collateral(:client_id, expected_collateral: amount);
+
+    // Withdraw full amount back.
+    state
+        .facade
+        .withdraw_from_prediction_account(
+            to_position_id: user.position_id, :client_id, quantized_amount: amount,
+        );
+
+    state
+        .facade
+        .validate_collateral_balance(
+            position_id: user.position_id, expected_balance: amount.into(),
+        );
+    state.facade.validate_prediction_collateral(:client_id, expected_collateral: 0);
+}
+
+#[test]
+#[should_panic(expected: "INSUFFICIENT_PREDICTION_COLLATERAL")]
+fn test_prediction_withdraw_insufficient_collateral() {
+    // Setup.
+    let mut state: FlowTestBase = FlowTestBaseTrait::new();
+    let user = state.new_user_with_position();
+
+    let deposit_info = state
+        .facade
+        .deposit(
+            depositor: user.account, position_id: user.position_id, quantized_amount: 100_000,
+        );
+    state.facade.process_deposit(deposit_info: deposit_info);
+
+    let client_id: felt252 = 1;
+    let owning_key: felt252 = 42;
+    state.facade.create_prediction_account(:client_id, :owning_key);
+
+    // Deposit 10,000.
+    state
+        .facade
+        .deposit_to_prediction_account(
+            from_position_id: user.position_id, :client_id, quantized_amount: 10_000,
+        );
+    state.facade.validate_prediction_collateral(:client_id, expected_collateral: 10_000);
+
+    // Try to withdraw 20,000 — should panic.
+    state
+        .facade
+        .withdraw_from_prediction_account(
+            to_position_id: user.position_id, :client_id, quantized_amount: 20_000,
+        );
+}
+
+#[test]
+#[should_panic(expected: "ACCOUNT_ALREADY_EXISTS")]
+fn test_prediction_create_duplicate_account() {
+    let mut state: FlowTestBase = FlowTestBaseTrait::new();
+
+    let client_id: felt252 = 1;
+    let owning_key: felt252 = 42;
+    state.facade.create_prediction_account(:client_id, :owning_key);
+
+    // Create again with same client_id — should panic.
+    state.facade.create_prediction_account(:client_id, owning_key: 99);
+}
+
+#[test]
+#[should_panic(expected: "INVALID_ZERO_OWNING_KEY")]
+fn test_prediction_create_account_zero_owning_key() {
+    let mut state: FlowTestBase = FlowTestBaseTrait::new();
+
+    state.facade.create_prediction_account(client_id: 1, owning_key: 0);
+}

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/prediction_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/prediction_tests.cairo
@@ -24,14 +24,14 @@ fn test_prediction_deposit_and_withdraw() {
         .create_prediction_account(:client_id, owning_key: owning_key_pair.public_key);
     state.facade.validate_prediction_collateral(:client_id, expected_collateral: 0);
 
-    // Deposit from perps position to prediction account.
+    // Deposit from perps position to prediction account (signed by position owner).
     state
         .facade
         .deposit_to_prediction_account(
             from_position_id: user.position_id,
             :client_id,
             quantized_amount: 50_000,
-            :owning_key_pair,
+            signing_key_pair: user.account.key_pair,
         );
 
     // Validate balances after deposit.
@@ -42,14 +42,14 @@ fn test_prediction_deposit_and_withdraw() {
         );
     state.facade.validate_prediction_collateral(:client_id, expected_collateral: 50_000);
 
-    // Withdraw from prediction account back to perps position.
+    // Withdraw from prediction account back to perps position (signed by prediction owner).
     state
         .facade
         .withdraw_from_prediction_account(
             to_position_id: user.position_id,
             :client_id,
             quantized_amount: 30_000,
-            :owning_key_pair,
+            signing_key_pair: owning_key_pair,
         );
 
     // Validate balances after withdraw.
@@ -87,7 +87,7 @@ fn test_prediction_deposit_full_and_withdraw_full() {
             from_position_id: user.position_id,
             :client_id,
             quantized_amount: amount,
-            :owning_key_pair,
+            signing_key_pair: user.account.key_pair,
         );
 
     state
@@ -102,7 +102,7 @@ fn test_prediction_deposit_full_and_withdraw_full() {
             to_position_id: user.position_id,
             :client_id,
             quantized_amount: amount,
-            :owning_key_pair,
+            signing_key_pair: owning_key_pair,
         );
 
     state
@@ -140,7 +140,7 @@ fn test_prediction_withdraw_insufficient_collateral() {
             from_position_id: user.position_id,
             :client_id,
             quantized_amount: 10_000,
-            :owning_key_pair,
+            signing_key_pair: user.account.key_pair,
         );
     state.facade.validate_prediction_collateral(:client_id, expected_collateral: 10_000);
 
@@ -151,7 +151,7 @@ fn test_prediction_withdraw_insufficient_collateral() {
             to_position_id: user.position_id,
             :client_id,
             quantized_amount: 20_000,
-            :owning_key_pair,
+            signing_key_pair: owning_key_pair,
         );
 }
 
@@ -179,4 +179,46 @@ fn test_prediction_create_account_zero_owning_key() {
     let mut state: FlowTestBase = FlowTestBaseTrait::new();
 
     state.facade.create_prediction_account(client_id: 1, owning_key: 0);
+}
+
+#[test]
+#[should_panic(expected: "ACCOUNT_DOES_NOT_EXIST")]
+fn test_prediction_deposit_nonexistent_account() {
+    let mut state: FlowTestBase = FlowTestBaseTrait::new();
+    let user = state.new_user_with_position();
+
+    let deposit_info = state
+        .facade
+        .deposit(
+            depositor: user.account, position_id: user.position_id, quantized_amount: 100_000,
+        );
+    state.facade.process_deposit(deposit_info: deposit_info);
+
+    // Deposit to non-existent prediction account — should panic.
+    state
+        .facade
+        .deposit_to_prediction_account(
+            from_position_id: user.position_id,
+            client_id: 999,
+            quantized_amount: 10_000,
+            signing_key_pair: user.account.key_pair,
+        );
+}
+
+#[test]
+#[should_panic(expected: "ACCOUNT_DOES_NOT_EXIST")]
+fn test_prediction_withdraw_nonexistent_account() {
+    let mut state: FlowTestBase = FlowTestBaseTrait::new();
+    let user = state.new_user_with_position();
+
+    let owning_key_pair = StarkCurveKeyPairImpl::from_secret_key(42);
+    // Withdraw from non-existent prediction account — should panic.
+    state
+        .facade
+        .withdraw_from_prediction_account(
+            to_position_id: user.position_id,
+            client_id: 999,
+            quantized_amount: 10_000,
+            signing_key_pair: owning_key_pair,
+        );
 }

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/prediction_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/prediction_tests.cairo
@@ -1,5 +1,6 @@
 use perpetuals::tests::flow_tests::infra::*;
 use perpetuals::tests::flow_tests::perps_tests_facade::*;
+use snforge_std::signature::stark_curve::StarkCurveKeyPairImpl;
 
 #[test]
 fn test_prediction_deposit_and_withdraw() {
@@ -15,17 +16,22 @@ fn test_prediction_deposit_and_withdraw() {
         );
     state.facade.process_deposit(deposit_info: deposit_info);
 
-    // Create prediction account.
+    // Create prediction account with a real key pair.
     let client_id: felt252 = 1;
-    let owning_key: felt252 = 42;
-    state.facade.create_prediction_account(:client_id, :owning_key);
+    let owning_key_pair = StarkCurveKeyPairImpl::from_secret_key(42);
+    state
+        .facade
+        .create_prediction_account(:client_id, owning_key: owning_key_pair.public_key);
     state.facade.validate_prediction_collateral(:client_id, expected_collateral: 0);
 
     // Deposit from perps position to prediction account.
     state
         .facade
         .deposit_to_prediction_account(
-            from_position_id: user.position_id, :client_id, quantized_amount: 50_000,
+            from_position_id: user.position_id,
+            :client_id,
+            quantized_amount: 50_000,
+            :owning_key_pair,
         );
 
     // Validate balances after deposit.
@@ -40,7 +46,10 @@ fn test_prediction_deposit_and_withdraw() {
     state
         .facade
         .withdraw_from_prediction_account(
-            to_position_id: user.position_id, :client_id, quantized_amount: 30_000,
+            to_position_id: user.position_id,
+            :client_id,
+            quantized_amount: 30_000,
+            :owning_key_pair,
         );
 
     // Validate balances after withdraw.
@@ -68,12 +77,17 @@ fn test_prediction_deposit_full_and_withdraw_full() {
 
     // Create prediction account and deposit full amount.
     let client_id: felt252 = 1;
-    let owning_key: felt252 = 42;
-    state.facade.create_prediction_account(:client_id, :owning_key);
+    let owning_key_pair = StarkCurveKeyPairImpl::from_secret_key(42);
+    state
+        .facade
+        .create_prediction_account(:client_id, owning_key: owning_key_pair.public_key);
     state
         .facade
         .deposit_to_prediction_account(
-            from_position_id: user.position_id, :client_id, quantized_amount: amount,
+            from_position_id: user.position_id,
+            :client_id,
+            quantized_amount: amount,
+            :owning_key_pair,
         );
 
     state
@@ -85,7 +99,10 @@ fn test_prediction_deposit_full_and_withdraw_full() {
     state
         .facade
         .withdraw_from_prediction_account(
-            to_position_id: user.position_id, :client_id, quantized_amount: amount,
+            to_position_id: user.position_id,
+            :client_id,
+            quantized_amount: amount,
+            :owning_key_pair,
         );
 
     state
@@ -111,14 +128,19 @@ fn test_prediction_withdraw_insufficient_collateral() {
     state.facade.process_deposit(deposit_info: deposit_info);
 
     let client_id: felt252 = 1;
-    let owning_key: felt252 = 42;
-    state.facade.create_prediction_account(:client_id, :owning_key);
+    let owning_key_pair = StarkCurveKeyPairImpl::from_secret_key(42);
+    state
+        .facade
+        .create_prediction_account(:client_id, owning_key: owning_key_pair.public_key);
 
     // Deposit 10,000.
     state
         .facade
         .deposit_to_prediction_account(
-            from_position_id: user.position_id, :client_id, quantized_amount: 10_000,
+            from_position_id: user.position_id,
+            :client_id,
+            quantized_amount: 10_000,
+            :owning_key_pair,
         );
     state.facade.validate_prediction_collateral(:client_id, expected_collateral: 10_000);
 
@@ -126,7 +148,10 @@ fn test_prediction_withdraw_insufficient_collateral() {
     state
         .facade
         .withdraw_from_prediction_account(
-            to_position_id: user.position_id, :client_id, quantized_amount: 20_000,
+            to_position_id: user.position_id,
+            :client_id,
+            quantized_amount: 20_000,
+            :owning_key_pair,
         );
 }
 
@@ -136,11 +161,16 @@ fn test_prediction_create_duplicate_account() {
     let mut state: FlowTestBase = FlowTestBaseTrait::new();
 
     let client_id: felt252 = 1;
-    let owning_key: felt252 = 42;
-    state.facade.create_prediction_account(:client_id, :owning_key);
+    let owning_key_pair = StarkCurveKeyPairImpl::from_secret_key(42);
+    state
+        .facade
+        .create_prediction_account(:client_id, owning_key: owning_key_pair.public_key);
 
     // Create again with same client_id — should panic.
-    state.facade.create_prediction_account(:client_id, owning_key: 99);
+    let other_key_pair = StarkCurveKeyPairImpl::from_secret_key(99);
+    state
+        .facade
+        .create_prediction_account(:client_id, owning_key: other_key_pair.public_key);
 }
 
 #[test]


### PR DESCRIPTION
This PR adds prediction markets deposits where:

We can pull from any positionID after verifying a signature against its owning key;
Verify the pulled USDC does not violate health checks on the positions
Deposit as freely available cash balance within a separate predictions account.


There is also support for withdraws, that pull any freely available usdc.

New components have been added to isolate the storage needed for the new prediction positions.