### PR TITLE
inreased multiplication space from u64 to u128.

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/components/deposit/deposit_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/deposit/deposit_manager.cairo
@@ -258,7 +258,7 @@ pub(crate) mod DepositManager {
                 (token_contract, asset_config.quantum, position_diff)
             };
 
-            let unquantized_amount: u256 = quantized_amount.into() * quantum.into();
+            let unquantized_amount: u128 = quantized_amount.into() * quantum.into();
             let deposit_hash = deposit_hash(
                 token_address: token_contract.contract_address,
                 :depositor,
@@ -372,7 +372,7 @@ pub(crate) mod DepositManager {
                 .registered_deposits
                 .write(key: deposit_hash, value: DepositStatus::PENDING(now));
 
-            let unquantized_amount = quantized_amount * quantum.into();
+            let unquantized_amount: u128 = quantized_amount.into() * quantum.into();
 
             assert(
                 token_contract
@@ -422,7 +422,7 @@ pub(crate) mod DepositManager {
                 (token_contract, asset_config.quantum)
             };
 
-            let unquantized_amount: u256 = quantized_amount.into() * quantum.into();
+            let unquantized_amount: u128 = quantized_amount.into() * quantum.into();
 
             let deposit_hash = deposit_hash(
                 token_address: token_contract.contract_address,

--- a/workspace/apps/perpetuals/contracts/src/core/components/deposit/events.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/deposit/events.cairo
@@ -11,7 +11,7 @@ pub struct Deposit {
     pub collateral_id: AssetId,
     pub token_address: ContractAddress,
     pub quantized_amount: u64,
-    pub unquantized_amount: u64,
+    pub unquantized_amount: u128,
     #[key]
     pub deposit_request_hash: felt252,
     pub salt: felt252,
@@ -26,7 +26,7 @@ pub struct DepositProcessed {
     pub collateral_id: AssetId,
     pub token_address: ContractAddress,
     pub quantized_amount: u64,
-    pub unquantized_amount: u256,
+    pub unquantized_amount: u128,
     #[key]
     pub deposit_request_hash: felt252,
     pub salt: felt252,
@@ -41,7 +41,7 @@ pub struct DepositCanceled {
     pub collateral_id: AssetId,
     pub token_address: ContractAddress,
     pub quantized_amount: u64,
-    pub unquantized_amount: u256,
+    pub unquantized_amount: u128,
     #[key]
     pub deposit_request_hash: felt252,
     pub salt: felt252,

--- a/workspace/apps/perpetuals/contracts/src/core/components/forced_requests/forced_requests_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/forced_requests/forced_requests_manager.cairo
@@ -419,15 +419,17 @@ pub(crate) mod ForcedRequestsManager {
             let premium_cost = self.premium_cost.read();
             let quantum = self.assets.get_collateral_quantum();
             let token_contract = self.assets.get_base_collateral_token_contract();
-            let amount: u256 = (premium_cost * quantum).into();
+            let amount: u128 = premium_cost.into() * quantum.into();
             let outstanding_allowance = token_contract
                 .allowance(owner: caller, spender: get_contract_address());
-            assert(outstanding_allowance >= amount, INSUFFICIENT_APPROVAL);
+            assert(outstanding_allowance >= amount.into(), INSUFFICIENT_APPROVAL);
 
             assert(
                 token_contract
                     .transfer_from(
-                        sender: caller, recipient: get_block_info().sequencer_address, :amount,
+                        sender: caller,
+                        recipient: get_block_info().sequencer_address,
+                        amount: amount.into(),
                     ),
                 TRANSFER_FAILED,
             );

--- a/workspace/apps/perpetuals/contracts/src/core/components/withdrawal/withdrawal_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/withdrawal/withdrawal_manager.cairo
@@ -431,7 +431,7 @@ pub(crate) mod WithdrawalManager {
                 );
 
             self.positions.apply_diff(:position_id, :position_diff);
-            let withdraw_unquantized_amount = quantum * amount;
+            let withdraw_unquantized_amount: u128 = quantum.into() * amount.into();
             assert(
                 token_contract.transfer(:recipient, amount: withdraw_unquantized_amount.into()),
                 TRANSFER_FAILED,

--- a/workspace/apps/perpetuals/contracts/src/core/core.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/core.cairo
@@ -1156,7 +1156,10 @@ pub mod Core {
             check_signature: bool,
         ) -> (PositionTVTR, PositionTVTR) {
             let synthetic_asset = self.assets.get_asset_config(order_a.base_asset_id);
-            assert(synthetic_asset.asset_type != AssetType::VAULT_SHARE_COLLATERAL, 'VAULT_SHARE_NO_TRADE');
+            assert(
+                synthetic_asset.asset_type != AssetType::VAULT_SHARE_COLLATERAL,
+                'VAULT_SHARE_NO_TRADE',
+            );
             validate_trade(
                 :order_a,
                 :order_b,

--- a/workspace/apps/perpetuals/contracts/src/tests/event_test_utils.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/event_test_utils.cairo
@@ -43,7 +43,7 @@ pub fn assert_deposit_event_with_expected(
     collateral_id: AssetId,
     token_address: ContractAddress,
     quantized_amount: u64,
-    unquantized_amount: u64,
+    unquantized_amount: u128,
     deposit_request_hash: felt252,
     salt: felt252,
 ) {
@@ -73,7 +73,7 @@ pub fn assert_deposit_canceled_event_with_expected(
     collateral_id: AssetId,
     token_address: ContractAddress,
     quantized_amount: u64,
-    unquantized_amount: u64,
+    unquantized_amount: u128,
     deposit_request_hash: felt252,
     salt: felt252,
 ) {
@@ -83,7 +83,7 @@ pub fn assert_deposit_canceled_event_with_expected(
         collateral_id,
         token_address,
         quantized_amount,
-        unquantized_amount: unquantized_amount.into(),
+        unquantized_amount,
         deposit_request_hash,
         salt,
     };
@@ -102,7 +102,7 @@ pub fn assert_deposit_processed_event_with_expected(
     collateral_id: AssetId,
     token_address: ContractAddress,
     quantized_amount: u64,
-    unquantized_amount: u64,
+    unquantized_amount: u128,
     deposit_request_hash: felt252,
     salt: felt252,
 ) {
@@ -112,7 +112,7 @@ pub fn assert_deposit_processed_event_with_expected(
         collateral_id,
         token_address,
         quantized_amount,
-        unquantized_amount: unquantized_amount.into(),
+        unquantized_amount,
         deposit_request_hash,
         salt,
     };

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/perps_tests_facade.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/perps_tests_facade.cairo
@@ -870,7 +870,7 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
             let dispatcher = IAssetsDispatcher { contract_address: self.perpetuals_contract };
             dispatcher.get_asset_config(asset_id: asset_id).quantum
         };
-        let unquantized_amount = quantized_amount * quantum;
+        let unquantized_amount: u128 = quantized_amount.into() * quantum.into();
         let address = depositor.address;
 
         let token_state = self.find_contract_for_asset_id(:asset_id);
@@ -949,7 +949,7 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
             :salt,
         );
 
-        let unquantized_amount = quantized_amount * self.collateral_quantum;
+        let unquantized_amount: u128 = quantized_amount.into() * self.collateral_quantum.into();
 
         validate_balance(
             token_state: token_state,
@@ -1047,7 +1047,7 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
             collateral_id: asset_id,
             token_address: token_state.address,
             :quantized_amount,
-            unquantized_amount: quantized_amount * self.collateral_quantum,
+            unquantized_amount: quantized_amount.into() * self.collateral_quantum.into(),
             deposit_request_hash: deposit_hash,
             :salt,
         );

--- a/workspace/apps/perpetuals/contracts/src/tests/unit_tests/unit_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/unit_tests/unit_tests.cairo
@@ -1967,7 +1967,7 @@ fn test_successful_deposit() {
         collateral_id: cfg.collateral_cfg.collateral_id,
         token_address: token_state.address,
         quantized_amount: DEPOSIT_AMOUNT,
-        unquantized_amount: DEPOSIT_AMOUNT * COLLATERAL_QUANTUM,
+        unquantized_amount: DEPOSIT_AMOUNT.into() * COLLATERAL_QUANTUM.into(),
         deposit_request_hash: deposit_hash,
         salt: user.salt_counter,
     );
@@ -2122,7 +2122,7 @@ fn test_successful_process_deposit() {
         collateral_id: cfg.collateral_cfg.collateral_id,
         token_address: token_state.address,
         quantized_amount: DEPOSIT_AMOUNT,
-        unquantized_amount: DEPOSIT_AMOUNT * COLLATERAL_QUANTUM,
+        unquantized_amount: DEPOSIT_AMOUNT.into() * COLLATERAL_QUANTUM.into(),
         deposit_request_hash: deposit_hash,
         salt: user.salt_counter,
     );
@@ -2198,7 +2198,7 @@ fn test_successful_cancel_deposit() {
         collateral_id: cfg.collateral_cfg.collateral_id,
         token_address: token_state.address,
         quantized_amount: DEPOSIT_AMOUNT,
-        unquantized_amount: DEPOSIT_AMOUNT * COLLATERAL_QUANTUM,
+        unquantized_amount: DEPOSIT_AMOUNT.into() * COLLATERAL_QUANTUM.into(),
         deposit_request_hash: deposit_hash,
         salt: user.salt_counter,
     );
@@ -2277,7 +2277,7 @@ fn test_successful_reject_deposit() {
         collateral_id: cfg.collateral_cfg.collateral_id,
         token_address: token_state.address,
         quantized_amount: DEPOSIT_AMOUNT,
-        unquantized_amount: DEPOSIT_AMOUNT * COLLATERAL_QUANTUM,
+        unquantized_amount: DEPOSIT_AMOUNT.into() * COLLATERAL_QUANTUM.into(),
         deposit_request_hash: deposit_hash,
         salt: user.salt_counter,
     );
@@ -5488,7 +5488,7 @@ fn test_successful_vault_token_deposit() {
         collateral_id: cfg.vault_share_cfg.collateral_id,
         token_address: cfg.vault_share_cfg.contract_address,
         quantized_amount: DEPOSIT_AMOUNT,
-        unquantized_amount: DEPOSIT_AMOUNT * cfg.vault_share_cfg.quantum,
+        unquantized_amount: DEPOSIT_AMOUNT.into() * cfg.vault_share_cfg.quantum.into(),
         deposit_request_hash: deposit_hash,
         salt: user.salt_counter,
     );
@@ -5629,7 +5629,7 @@ fn test_successful_vault_token_cancel_deposit() {
         collateral_id: cfg.vault_share_cfg.collateral_id,
         token_address: cfg.vault_share_cfg.contract_address,
         quantized_amount: DEPOSIT_AMOUNT,
-        unquantized_amount: DEPOSIT_AMOUNT * cfg.vault_share_cfg.quantum,
+        unquantized_amount: DEPOSIT_AMOUNT.into() * cfg.vault_share_cfg.quantum.into(),
         deposit_request_hash: deposit_hash,
         salt: user.salt_counter,
     );
@@ -5659,7 +5659,7 @@ fn test_successful_vault_token_cancel_deposit() {
         collateral_id: cfg.vault_share_cfg.collateral_id,
         token_address: vault_share_state.address,
         quantized_amount: DEPOSIT_AMOUNT,
-        unquantized_amount: DEPOSIT_AMOUNT * cfg.vault_share_cfg.quantum,
+        unquantized_amount: DEPOSIT_AMOUNT.into() * cfg.vault_share_cfg.quantum.into(),
         deposit_request_hash: deposit_hash,
         salt: user.salt_counter,
     );
@@ -5740,7 +5740,7 @@ fn test_successful_vault_share_process_deposit() {
         collateral_id: cfg.vault_share_cfg.collateral_id,
         token_address: vault_share_state.address,
         quantized_amount: DEPOSIT_AMOUNT,
-        unquantized_amount: DEPOSIT_AMOUNT * cfg.vault_share_cfg.quantum,
+        unquantized_amount: DEPOSIT_AMOUNT.into() * cfg.vault_share_cfg.quantum.into(),
         deposit_request_hash: deposit_hash,
         salt: user.salt_counter,
     );


### PR DESCRIPTION
https://hackmd.io/@kaliberp/B1J_D022-e#Medium-Deposits-withdrawals-and-forced-action-premiums-are-limited-to-18-whole-tokens-for-any-18-decimal-ERC20-due-to-u64-overflow fix for security audit issue