### PR TITLE
Change comment and spec.

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/components/assets/assets.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/assets/assets.cairo
@@ -509,10 +509,10 @@ pub mod AssetsComponent {
 
         /// Get the risk factor of a synthetic asset.
         ///   - synthetic_value = |price * balance|
-        ///   - If the synthetic value is less than or equal to the first tier boundary, return the
+        ///   - If the synthetic value is strictly less than the first tier boundary, return the
         ///   first risk factor.
-        ///   - index = (synthetic_value - risk_factor_first_tier_boundary) / risk_factor_tier_size
-        ///   - risk_factor = risk_factor_tiers[index]
+        ///   - index = 1 + (synthetic_value - risk_factor_first_tier_boundary) /
+        ///   risk_factor_tier_size - risk_factor = risk_factor_tiers[index]
         ///   - If the index is out of bounds, return the last risk factor.
         /// - If the asset is not synthetic, panic.
         fn get_asset_risk_factor(
@@ -534,10 +534,10 @@ pub mod AssetsComponent {
 
         /// Get the risk factor of a synthetic asset.
         ///   - synthetic_value = |price * balance|
-        ///   - If the synthetic value is less than or equal to the first tier boundary, return the
+        ///   - If the synthetic value is strictly less than the first tier boundary, return the
         ///   first risk factor.
-        ///   - index = (synthetic_value - risk_factor_first_tier_boundary) / risk_factor_tier_size
-        ///   - risk_factor = risk_factor_tiers[index]
+        ///   - index = 1 + (synthetic_value - risk_factor_first_tier_boundary) /
+        ///   risk_factor_tier_size - risk_factor = risk_factor_tiers[index]
         ///   - If the index is out of bounds, return the last risk factor.
         /// - If the asset is not synthetic, panic.
         fn get_synthetic_risk_factor_for_value(

--- a/workspace/apps/perpetuals/contracts/src/core/components/exchange_time/exchange_time.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/exchange_time/exchange_time.cairo
@@ -86,7 +86,7 @@ pub mod ExchangeTimeComponent {
             assert(new_timestamp > current_exchange_time, NON_MONOTONIC_TIME);
 
             let now = Time::now();
-            // The new exchange time cannot be more than a day in the past.
+            // The new exchange time cannot be more than a week in the past.
             let min_acceptable_time = now.sub_delta(Time::seconds(WEEK));
             assert(new_timestamp > min_acceptable_time, TIMESTAMP_TOO_OLD);
 

--- a/workspace/apps/perpetuals/contracts/src/core/core.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/core.cairo
@@ -1156,7 +1156,10 @@ pub mod Core {
             check_signature: bool,
         ) -> (PositionTVTR, PositionTVTR) {
             let synthetic_asset = self.assets.get_asset_config(order_a.base_asset_id);
-            assert(synthetic_asset.asset_type != AssetType::VAULT_SHARE_COLLATERAL, 'VAULT_SHARE_NO_TRADE');
+            assert(
+                synthetic_asset.asset_type != AssetType::VAULT_SHARE_COLLATERAL,
+                'VAULT_SHARE_NO_TRADE',
+            );
             validate_trade(
                 :order_a,
                 :order_b,


### PR DESCRIPTION
This PR addresses:
[[Info] Incorrect comment in the update_exchange_time function 
](https://hackmd.io/@kaliberp/B1J_D022-e#Info-Incorrect-comment-in-the-update_exchange_time-function)
[[Low] Off-by-one check in the synthetic risk factor calculation penalizes exact boundary positions
](https://hackmd.io/@kaliberp/B1J_D022-e#Low-Off-by-one-check-in-the-synthetic-risk-factor-calculation-penalizes-exact-boundary-positions)
