### PR TITLE
Panic on forced ops calls. 

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/components/forced_requests/forced_requests_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/forced_requests/forced_requests_manager.cairo
@@ -182,6 +182,7 @@ pub(crate) mod ForcedRequestsManager {
             expiration: Timestamp,
             salt: felt252,
         ) -> HashType {
+            panic!("forced requests are disabled");
             assert(self._is_escape_hatch_enabled(), ESCAPE_HATCH_DISABLED);
             assert(!self.vaults.is_vault_position(position_id), 'VAULT_CANNOT_INITIATE_WITHDRAW');
 
@@ -267,6 +268,7 @@ pub(crate) mod ForcedRequestsManager {
             order_a: Order,
             order_b: Order,
         ) {
+            panic!("forced requests are disabled");
             assert(self._is_escape_hatch_enabled(), ESCAPE_HATCH_DISABLED);
             let position_a = self.positions.get_position_snapshot(position_id: order_a.position_id);
             let position_b = self.positions.get_position_snapshot(position_id: order_b.position_id);
@@ -341,6 +343,7 @@ pub(crate) mod ForcedRequestsManager {
             order: LimitOrder,
             vault_approval: LimitOrder,
         ) {
+            panic!("forced requests are disabled");
             assert(self._is_escape_hatch_enabled(), ESCAPE_HATCH_DISABLED);
 
             let redeeming_position = self

--- a/workspace/apps/perpetuals/contracts/src/core/core.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/core.cairo
@@ -811,6 +811,7 @@ pub mod Core {
             expiration: Timestamp,
             salt: felt252,
         ) {
+            panic!("forced requests are disabled");
             self
                 .external_components
                 ._get_withdrawal_manager_dispatcher()
@@ -857,6 +858,7 @@ pub mod Core {
         fn forced_trade(
             ref self: ContractState, operator_nonce: u64, order_a: Order, order_b: Order,
         ) {
+            panic!("forced requests are disabled");
             let position_a = self.positions.get_position_snapshot(position_id: order_a.position_id);
             let position_b = self.positions.get_position_snapshot(position_id: order_b.position_id);
             let public_key_a = position_a.get_owner_public_key();
@@ -973,6 +975,7 @@ pub mod Core {
             order: LimitOrder,
             vault_approval: LimitOrder,
         ) {
+            panic!("forced requests are disabled");
             let redeeming_position = self
                 .positions
                 .get_position_snapshot(position_id: order.source_position);

--- a/workspace/apps/perpetuals/contracts/src/core/core.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/core.cairo
@@ -1159,7 +1159,10 @@ pub mod Core {
             check_signature: bool,
         ) -> (PositionTVTR, PositionTVTR) {
             let synthetic_asset = self.assets.get_asset_config(order_a.base_asset_id);
-            assert(synthetic_asset.asset_type != AssetType::VAULT_SHARE_COLLATERAL, 'VAULT_SHARE_NO_TRADE');
+            assert(
+                synthetic_asset.asset_type != AssetType::VAULT_SHARE_COLLATERAL,
+                'VAULT_SHARE_NO_TRADE',
+            );
             validate_trade(
                 :order_a,
                 :order_b,

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/procotol_vault_redeem_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/procotol_vault_redeem_tests.cairo
@@ -1487,6 +1487,7 @@ fn test_redeem_vault_shares_negative() {
 }
 
 #[test]
+#[ignore]
 fn test_forced_redeem_from_vault_request() {
     let mut state: FlowTestBase = FlowTestBaseTrait::new();
     state.facade.enable_escape_hatch();
@@ -1611,6 +1612,7 @@ fn test_forced_redeem_from_vault_request() {
 }
 
 #[test]
+#[ignore]
 fn test_forced_redeem_from_vault_after_timelock() {
     let mut state: FlowTestBase = FlowTestBaseTrait::new();
     state.facade.enable_escape_hatch();
@@ -1752,6 +1754,7 @@ fn test_forced_redeem_from_vault_after_timelock() {
 }
 
 #[test]
+#[ignore]
 fn test_forced_redeem_from_vault_by_operator_before_timelock() {
     let mut state: FlowTestBase = FlowTestBaseTrait::new();
     state.facade.enable_escape_hatch();
@@ -1847,6 +1850,7 @@ fn test_forced_redeem_from_vault_by_operator_before_timelock() {
 }
 
 #[test]
+#[ignore]
 #[should_panic(expected: 'FORCED_WAIT_REQUIRED')]
 fn test_forced_redeem_from_vault_user_before_timelock_fails() {
     let mut state: FlowTestBase = FlowTestBaseTrait::new();
@@ -1917,6 +1921,7 @@ fn test_forced_redeem_from_vault_user_before_timelock_fails() {
 }
 
 #[test]
+#[ignore]
 #[should_panic(expected: 'REQUEST_ALREADY_PROCESSED')]
 fn test_forced_redeem_from_vault_user_after_operator_already_redeemed_fails() {
     let mut state: FlowTestBase = FlowTestBaseTrait::new();
@@ -1993,6 +1998,7 @@ fn test_forced_redeem_from_vault_user_after_operator_already_redeemed_fails() {
 }
 
 #[test]
+#[ignore]
 #[should_panic(expected: 'REQUEST_ALREADY_PROCESSED')]
 fn test_forced_redeem_from_vault_operator_after_user_already_redeemed_fails() {
     let mut state: FlowTestBase = FlowTestBaseTrait::new();

--- a/workspace/apps/perpetuals/contracts/src/tests/unit_tests/unit_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/unit_tests/unit_tests.cairo
@@ -6775,10 +6775,7 @@ fn test_forced_trade_request_panics_when_disabled() {
 
     state
         .forced_trade_request(
-            signature_a: array![].span(),
-            signature_b: array![].span(),
-            :order_a,
-            :order_b,
+            signature_a: array![].span(), signature_b: array![].span(), :order_a, :order_b,
         );
 }
 

--- a/workspace/apps/perpetuals/contracts/src/tests/unit_tests/unit_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/unit_tests/unit_tests.cairo
@@ -23,8 +23,8 @@ use perpetuals::core::interface::{
 use perpetuals::core::types::asset::{AssetId, AssetIdTrait, AssetStatus};
 use perpetuals::core::types::balance::{Balance, BalanceTrait};
 use perpetuals::core::types::funding::{FUNDING_SCALE, FundingIndex, FundingTick};
-use perpetuals::core::types::order::{ForcedTrade, Order};
-use perpetuals::core::types::position::{POSITION_VERSION, PositionMutableTrait};
+use perpetuals::core::types::order::{ForcedTrade, LimitOrder, Order};
+use perpetuals::core::types::position::{POSITION_VERSION, PositionId, PositionMutableTrait};
 use perpetuals::core::types::price::{
     PRICE_SCALE, PriceTrait, SignedPrice, convert_oracle_to_perps_price,
 };
@@ -2743,6 +2743,7 @@ fn test_successful_withdraw_request_with_public_key() {
 // Forced withdraw tests.
 
 #[test]
+#[ignore]
 fn test_successful_forced_withdraw_request() {
     // Setup:
     let cfg: PerpetualsInitConfig = Default::default();
@@ -2839,6 +2840,7 @@ fn test_successful_forced_withdraw_request() {
 }
 
 #[test]
+#[ignore]
 fn test_successful_forced_withdraw_operator_executes() {
     // Setup:
     let cfg: PerpetualsInitConfig = Default::default();
@@ -2994,6 +2996,7 @@ fn test_successful_forced_withdraw_operator_executes() {
 }
 
 #[test]
+#[ignore]
 fn test_successful_forced_withdraw_user_executes() {
     // Setup:
     let cfg: PerpetualsInitConfig = Default::default();
@@ -3163,6 +3166,7 @@ fn test_successful_forced_withdraw_user_executes() {
 }
 
 #[test]
+#[ignore]
 #[should_panic(expected: 'FORCED_WAIT_REQUIRED')]
 fn test_forced_withdraw_before_timeout() {
     // Setup:
@@ -3265,6 +3269,7 @@ fn test_forced_withdraw_before_timeout() {
 }
 
 #[test]
+#[ignore]
 #[should_panic(expected: 'REQUEST_ALREADY_PROCESSED')]
 fn test_forced_withdraw_after_operator_processed_withdraw() {
     // Setup:
@@ -3391,6 +3396,7 @@ fn test_forced_withdraw_after_operator_processed_withdraw() {
 }
 
 #[test]
+#[ignore]
 #[should_panic(expected: 'REQUEST_ALREADY_PROCESSED')]
 fn test_withdraw_after_user_forced_withdraw_executed() {
     // Setup:
@@ -3525,6 +3531,7 @@ fn test_withdraw_after_user_forced_withdraw_executed() {
 }
 
 #[test]
+#[ignore]
 #[should_panic(expected: 'INVALID_ZERO_AMOUNT')]
 fn test_forced_withdraw_request_zero_amount() {
     // Setup state, token and user:
@@ -6680,4 +6687,146 @@ fn test_withdraw_non_existent_asset() {
             salt: withdraw_args.salt,
             interest_amount: 0,
         );
+}
+
+// Forced requests disabled tests.
+
+fn dummy_order(position_id: PositionId, base_asset_id: AssetId, quote_asset_id: AssetId) -> Order {
+    Order {
+        position_id,
+        salt: 0,
+        base_asset_id,
+        base_amount: 1,
+        quote_asset_id,
+        quote_amount: -1,
+        fee_asset_id: quote_asset_id,
+        fee_amount: 0,
+        expiration: Time::now().add(delta: Time::days(1)),
+    }
+}
+
+fn dummy_limit_order(
+    position_id: PositionId, base_asset_id: AssetId, quote_asset_id: AssetId,
+) -> LimitOrder {
+    LimitOrder {
+        source_position: position_id,
+        receive_position: position_id,
+        base_asset_id,
+        base_amount: -1,
+        quote_asset_id,
+        quote_amount: 1,
+        fee_asset_id: quote_asset_id,
+        fee_amount: 0,
+        expiration: Time::now().add(delta: Time::days(1)),
+        salt: 0,
+    }
+}
+
+#[test]
+#[should_panic(expected: "forced requests are disabled")]
+fn test_forced_withdraw_request_panics_when_disabled() {
+    let cfg: PerpetualsInitConfig = Default::default();
+    let token_state = cfg.collateral_cfg.token_cfg.deploy();
+    let mut state = setup_state_with_active_synthetic(cfg: @cfg, token_state: @token_state);
+    let user: User = Default::default();
+
+    state
+        .forced_withdraw_request(
+            signature: array![].span(),
+            collateral_id: cfg.collateral_cfg.collateral_id,
+            recipient: user.address,
+            position_id: user.position_id,
+            amount: 1,
+            expiration: Time::now().add(delta: Time::days(1)),
+            salt: 0,
+        );
+}
+
+#[test]
+#[should_panic(expected: "forced requests are disabled")]
+fn test_forced_withdraw_panics_when_disabled() {
+    let cfg: PerpetualsInitConfig = Default::default();
+    let token_state = cfg.collateral_cfg.token_cfg.deploy();
+    let mut state = setup_state_with_active_synthetic(cfg: @cfg, token_state: @token_state);
+    let user: User = Default::default();
+
+    state
+        .forced_withdraw(
+            collateral_id: cfg.collateral_cfg.collateral_id,
+            recipient: user.address,
+            position_id: user.position_id,
+            amount: 1,
+            expiration: Time::now().add(delta: Time::days(1)),
+            salt: 0,
+        );
+}
+
+#[test]
+#[should_panic(expected: "forced requests are disabled")]
+fn test_forced_trade_request_panics_when_disabled() {
+    let cfg: PerpetualsInitConfig = Default::default();
+    let token_state = cfg.collateral_cfg.token_cfg.deploy();
+    let mut state = setup_state_with_active_synthetic(cfg: @cfg, token_state: @token_state);
+    let user: User = Default::default();
+    let order_a = dummy_order(
+        user.position_id, cfg.synthetic_cfg.synthetic_id, cfg.collateral_cfg.collateral_id,
+    );
+    let order_b = order_a;
+
+    state
+        .forced_trade_request(
+            signature_a: array![].span(),
+            signature_b: array![].span(),
+            :order_a,
+            :order_b,
+        );
+}
+
+#[test]
+#[should_panic(expected: "forced requests are disabled")]
+fn test_forced_trade_panics_when_disabled() {
+    let cfg: PerpetualsInitConfig = Default::default();
+    let token_state = cfg.collateral_cfg.token_cfg.deploy();
+    let mut state = setup_state_with_active_synthetic(cfg: @cfg, token_state: @token_state);
+    let user: User = Default::default();
+    let order_a = dummy_order(
+        user.position_id, cfg.synthetic_cfg.synthetic_id, cfg.collateral_cfg.collateral_id,
+    );
+    let order_b = order_a;
+
+    state.forced_trade(operator_nonce: 0, :order_a, :order_b);
+}
+
+#[test]
+#[should_panic(expected: "forced requests are disabled")]
+fn test_forced_redeem_from_vault_request_panics_when_disabled() {
+    let cfg: PerpetualsInitConfig = Default::default();
+    let token_state = cfg.collateral_cfg.token_cfg.deploy();
+    let mut state = setup_state_with_active_synthetic(cfg: @cfg, token_state: @token_state);
+    let user: User = Default::default();
+    let order = dummy_limit_order(
+        user.position_id, cfg.synthetic_cfg.synthetic_id, cfg.collateral_cfg.collateral_id,
+    );
+
+    state
+        .forced_redeem_from_vault_request(
+            signature: array![].span(),
+            vault_signature: array![].span(),
+            :order,
+            vault_approval: order,
+        );
+}
+
+#[test]
+#[should_panic(expected: "forced requests are disabled")]
+fn test_forced_redeem_from_vault_panics_when_disabled() {
+    let cfg: PerpetualsInitConfig = Default::default();
+    let token_state = cfg.collateral_cfg.token_cfg.deploy();
+    let mut state = setup_state_with_active_synthetic(cfg: @cfg, token_state: @token_state);
+    let user: User = Default::default();
+    let order = dummy_limit_order(
+        user.position_id, cfg.synthetic_cfg.synthetic_id, cfg.collateral_cfg.collateral_id,
+    );
+
+    state.forced_redeem_from_vault(operator_nonce: 0, :order, vault_approval: order);
 }


### PR DESCRIPTION
Contract changed to ensure forced ops calls are permanently disabled until a further contract upgrade.