### PR TITLE
docs: fix typo in README - Staknet → Starknet

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 ## About
 
-This repo holds the implementation of Staknet Perpetual Trading contracts.  
+This repo holds the implementation of Starknet Perpetual Trading contracts.  
 
 ## Disclaimer
 


### PR DESCRIPTION
Minor typo fix in README.md - 'Staknet' should be 'Starknet'.